### PR TITLE
set console stdout to utf-8 mode

### DIFF
--- a/LogMonitor/src/LogMonitor/LogWriter.h
+++ b/LogMonitor/src/LogMonitor/LogWriter.h
@@ -21,6 +21,8 @@ public:
         }
 
         m_isConsole = true;
+        
+		_setmode(_fileno(stdout), _O_U8TEXT);
     };
 
     ~LogWriter() {};


### PR DESCRIPTION
Resolve Issue #30

The default console mode is _O_TEXT which not support Unicode Text, therefore the log monitor tool forwarded wrong encoded value to docker log.

References:
1. [_setmode method (MSDN)](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setmode?view=vs-2019)
2. ["_setmode(_fileno(stdout), _O_U8TEXT); + printf = ucrt crash" problem (VS DEV Community)](https://developercommunity.visualstudio.com/content/problem/394790/-setmode-filenostdout-o-u8text-printf-ucrt-crash.html)