### PR TITLE
Pass through exit code from monitored process to callers of LogMonitor

### DIFF
--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -230,6 +230,7 @@ int __cdecl wmain(int argc, WCHAR *argv[])
 {
     std::wstring cmdline;
     PWCHAR configFileName = (PWCHAR)DEFAULT_CONFIG_FILENAME;
+    int exitcode = 0;
 
     g_hStopEvent = CreateEvent(nullptr,            // default security attributes
                                TRUE,               // manual-reset event
@@ -288,7 +289,7 @@ int __cdecl wmain(int argc, WCHAR *argv[])
             cmdline += argv[i];
         }
 
-        CreateAndMonitorProcess(cmdline);
+        exitcode = CreateAndMonitorProcess(cmdline);
     }
     else
     {
@@ -304,6 +305,7 @@ int __cdecl wmain(int argc, WCHAR *argv[])
                 logWriter.TraceError(
                     Utility::FormatString(L"Log monitor wait failed. Error: %d", GetLastError()).c_str()
                 );
+                exitcode = 1;
                 break;
         }
     }
@@ -314,5 +316,5 @@ int __cdecl wmain(int argc, WCHAR *argv[])
         g_hStopEvent = INVALID_HANDLE_VALUE;
     }
 
-    return 0;
+    return exitcode;
 }


### PR DESCRIPTION
Fixes #36. Did not see the white space thing in VS...

@algamaes @manoj-kadam 