### PR TITLE
resolve x32 build error

### DIFF
--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<EventMonitor> g_eventMon(nullptr);
 std::vector<std::shared_ptr<LogFileMonitor>> g_logfileMonitors;
 std::unique_ptr<EtwMonitor> g_etwMon(nullptr);
 
-BOOL ControlHandle(_In_ DWORD dwCtrlType)
+BOOL WINAPI ControlHandle(_In_ DWORD dwCtrlType)
 {
     switch (dwCtrlType)
     {


### PR DESCRIPTION
**Repro steps**
1.	Open the LogMonitor solution using Microsoft Visual Studio
2.	Before building the solution, ensure to change the solution platform to x86
 
![image](https://user-images.githubusercontent.com/28774968/176135430-2cdc0956-ddf6-4971-a90a-625a36d7a4a9.png)

3.	Clean and build the solution.
4.	Confirm the errors displayed in the error list
 
![image](https://user-images.githubusercontent.com/28774968/176135475-213d2e51-9ffa-40b6-ac3a-28845284f499.png)


**Explanation**
The bug is related to the difference between __cdecl and __stdcall in x86 and x64. In x64 cdecl and stdcall, are the same, while in x86, cdecl has the caller clean (pop) the stack, while stdcall has the callee clean the stack


**Solution**
This issue can be resolved by using WINAPI. WINAPI is a macro that evaluates to [__stdcall](http://msdn.microsoft.com/en-us/library/zxk0tw93.aspx), a Microsoft-specific keyword that specifies a calling convention where the callee cleans the stack. The function's caller and callee need to agree on a calling convention to avoid corrupting the stack.


**Testing after change** 
Re-build the solution in the x86 platform, and confirm no errors are encountered: 
![image](https://user-images.githubusercontent.com/28774968/175891023-87483467-2820-4ad2-b989-67c808e2afc8.png)
 
Change the platform to x64 and re-build the solution, confirming that no errors are encountered during the build process: 
![image](https://user-images.githubusercontent.com/28774968/175891046-eab90135-5158-4995-8858-3854c390122b.png)