### PR TITLE
Add x86 build, update azure build agent and platform toolset

### DIFF
--- a/LogMonitor/LogMonitorTests/LogMonitorTests.vcxproj
+++ b/LogMonitor/LogMonitorTests/LogMonitorTests.vcxproj
@@ -23,21 +23,21 @@
     <ProjectGuid>{83EC485E-DF62-445A-B5DC-6AE352552B93}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>LogMonitorTests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
@@ -45,14 +45,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>

--- a/LogMonitor/LogMonitorTests/LogMonitorTests.vcxproj
+++ b/LogMonitor/LogMonitorTests/LogMonitorTests.vcxproj
@@ -23,21 +23,21 @@
     <ProjectGuid>{83EC485E-DF62-445A-B5DC-6AE352552B93}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>LogMonitorTests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
@@ -45,14 +45,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>

--- a/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
+++ b/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
@@ -23,32 +23,32 @@
     <ProjectGuid>{87A330AC-84A1-40B3-A596-1BAED16B828F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>LogMonitor</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
+++ b/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
@@ -23,32 +23,32 @@
     <ProjectGuid>{87A330AC-84A1-40B3-A596-1BAED16B828F}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>LogMonitor</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://dev.azure.com/ms/windows-container-tools/_apis/build/status/microsoft.windows-container-tools?branchName=master)](https://dev.azure.com/ms/windows-container-tools/_build/latest?definitionId=265&branchName=master)  [![Join the chat at https://gitter.im/Microsoft/windows-containers-tools](https://badges.gitter.im/Microsoft/windows-containers-tools.svg)](https://gitter.im/Microsoft/windows-containers-tools?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://dev.azure.com/ms/windows-container-tools/_apis/build/status/microsoft.windows-container-tools?branchName=main)](https://dev.azure.com/ms/windows-container-tools/_build/latest?definitionId=265&branchName=main)  [![Join the chat at https://gitter.im/Microsoft/windows-containers-tools](https://badges.gitter.im/Microsoft/windows-containers-tools.svg)](https://gitter.im/Microsoft/windows-containers-tools?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
 # Overview

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
 - main
 
 pool:
-    vmImage: 'windows-2019'  # name of the pool to run this job in
+    vmImage: 'windows-2022'  # name of the pool to run this job in
     demands: 
       - msbuild
       - visualstudio

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,3 +38,5 @@ steps:
     searchFolder: '$(System.DefaultWorkingDirectory)' 
     runOnlyImpactedTests: false
     runInParallel: false
+    rerunFailedTests: true
+    rerunMaxAttempts: 3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
 - main
 
 pool:
-    vmImage: 'windows-2022'  # name of the pool to run this job in
+    vmImage: 'windows-2019'  # name of the pool to run this job in
     demands: 
       - msbuild
       - visualstudio

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
 - main
 
 pool:
-    vmImage: 'windows-2019'  # name of the pool to run this job in
+    vmImage: 'windows-2022'  # name of the pool to run this job in
     demands: 
       - msbuild
       - visualstudio
@@ -13,30 +13,61 @@ variables:
   buildPlatform: 'x86|x64|ARM'
   buildConfiguration: 'Release'
 
-steps:
-- task: VSBuild@1
-  inputs:
-    platform: 'x64'
-    solution: '$(solution)'
-    configuration: '$(buildConfiguration)'
+jobs:
+  - job: x64_build
+    steps:
+    - task: VSBuild@1
+      inputs:
+        platform: 'x64'
+        solution: '$(solution)'
+        configuration: '$(buildConfiguration)'
 
-# - task: ComponentGovernanceComponentDetection@0
-#   inputs:
-#     scanType: 'LogOnly'
-#     verbosity: 'Verbose'
-#     alertWarningLevel: 'High'
+    # - task: ComponentGovernanceComponentDetection@0
+    #   inputs:
+    #     scanType: 'LogOnly'
+    #     verbosity: 'Verbose'
+    #     alertWarningLevel: 'High'
 
-- task: VisualStudioTestPlatformInstaller@1
-  inputs:
-    packageFeedSelector: 'nugetOrg'
-    versionSelector: 'latestPreRelease'
+    - task: VisualStudioTestPlatformInstaller@1
+      inputs:
+        packageFeedSelector: 'nugetOrg'
+        versionSelector: 'latestPreRelease'
 
-- task: VSTest@2
-  inputs:
-    testSelector: 'testAssemblies'
-    testAssemblyVer2: '**\*test*.dll'
-    searchFolder: '$(System.DefaultWorkingDirectory)' 
-    runOnlyImpactedTests: false
-    runInParallel: false
-    rerunFailedTests: true
-    rerunMaxAttempts: 3
+    - task: VSTest@2
+      inputs:
+        testSelector: 'testAssemblies'
+        testAssemblyVer2: '**\*test*.dll'
+        searchFolder: '$(System.DefaultWorkingDirectory)' 
+        runOnlyImpactedTests: false
+        runInParallel: false
+        rerunFailedTests: true
+        rerunMaxAttempts: 3
+    
+  - job: x86_build
+    steps:
+      - task: VSBuild@1
+        inputs:
+          platform: 'x32'
+          solution: '$(solution)'
+          configuration: '$(buildConfiguration)'
+
+      # - task: ComponentGovernanceComponentDetection@0
+      #   inputs:
+      #     scanType: 'LogOnly'
+      #     verbosity: 'Verbose'
+      #     alertWarningLevel: 'High'
+
+      - task: VisualStudioTestPlatformInstaller@1
+        inputs:
+          packageFeedSelector: 'nugetOrg'
+          versionSelector: 'latestPreRelease'
+
+      - task: VSTest@2
+        inputs:
+          testSelector: 'testAssemblies'
+          testAssemblyVer2: '**\*test*.dll'
+          searchFolder: '$(System.DefaultWorkingDirectory)' 
+          runOnlyImpactedTests: false
+          runInParallel: false
+          rerunFailedTests: true
+          rerunMaxAttempts: 3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - task: VSBuild@1
         inputs:
-          platform: 'x32'
+          platform: 'x86'
           solution: '$(solution)'
           configuration: '$(buildConfiguration)'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,11 +22,11 @@ jobs:
         solution: '$(solution)'
         configuration: '$(buildConfiguration)'
 
-    # - task: ComponentGovernanceComponentDetection@0
-    #   inputs:
-    #     scanType: 'LogOnly'
-    #     verbosity: 'Verbose'
-    #     alertWarningLevel: 'High'
+    - task: ComponentGovernanceComponentDetection@0
+      inputs:
+        scanType: 'LogOnly'
+        verbosity: 'Verbose'
+        alertWarningLevel: 'High'
 
     - task: VisualStudioTestPlatformInstaller@1
       inputs:
@@ -51,11 +51,11 @@ jobs:
           solution: '$(solution)'
           configuration: '$(buildConfiguration)'
 
-      # - task: ComponentGovernanceComponentDetection@0
-      #   inputs:
-      #     scanType: 'LogOnly'
-      #     verbosity: 'Verbose'
-      #     alertWarningLevel: 'High'
+      - task: ComponentGovernanceComponentDetection@0
+        inputs:
+          scanType: 'LogOnly'
+          verbosity: 'Verbose'
+          alertWarningLevel: 'High'
 
       - task: VisualStudioTestPlatformInstaller@1
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
 - main
 
 pool:
-    name: 'Hosted VS2017'  # name of the pool to run this job in
+    vmImage: 'windows-2019'  # name of the pool to run this job in
     demands: 
       - msbuild
       - visualstudio

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,11 +20,11 @@ steps:
     solution: '$(solution)'
     configuration: '$(buildConfiguration)'
 
-- task: ComponentGovernanceComponentDetection@0
-  inputs:
-    scanType: 'LogOnly'
-    verbosity: 'Verbose'
-    alertWarningLevel: 'High'
+# - task: ComponentGovernanceComponentDetection@0
+#   inputs:
+#     scanType: 'LogOnly'
+#     verbosity: 'Verbose'
+#     alertWarningLevel: 'High'
 
 - task: VisualStudioTestPlatformInstaller@1
   inputs:


### PR DESCRIPTION
- Added an x86 Build Job
- Updated build agent to Windows 2022 since 2016 build agents are deprecated
- Upgraded platform toolset to v142(Visual Studio 2019) and Set Windows SDK to 10.0 (latest available)