### PR TITLE
Add file name to logs (log file source)

### DIFF
--- a/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
+++ b/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
@@ -320,7 +320,8 @@ namespace LogMonitorTests
                                 \"type\": \"File\",\
                                 \"directory\": \"%s\",\
                                 \"filter\": \"%s\",\
-                                \"includeSubdirectories\" : %s\
+                                \"includeSubdirectories\": %s\,\
+                                \"includeFileNames\" : %s\
                             }\
                         ]\
                     }\
@@ -330,6 +331,7 @@ namespace LogMonitorTests
             // First, try with this values.
             //
             bool includeSubdirectories = true;
+            bool includeFileNames = true;
 
             std::wstring directory = L"C:\\LogMonitor\\logs";
             std::wstring filter = L"*.*";
@@ -338,7 +340,8 @@ namespace LogMonitorTests
                     configFileStrFormat.c_str(),
                     ReplaceAll(directory, L"\\", L"\\\\").c_str(),
                     filter.c_str(),
-                    includeSubdirectories ? L"true" : L"false"
+                    includeSubdirectories ? L"true" : L"false",
+                    includeFileNames ? L"true" : L"false"
                 );
 
                 JsonFileParser jsonParser(configFileStr);
@@ -365,12 +368,14 @@ namespace LogMonitorTests
                 Assert::AreEqual(directory.c_str(), sourceFile->Directory.c_str());
                 Assert::AreEqual(filter.c_str(), sourceFile->Filter.c_str());
                 Assert::AreEqual(includeSubdirectories, sourceFile->IncludeSubdirectories);
+                Assert::AreEqual(includeFileNames, sourceFile->IncludeFileNames);
             }
 
             //
             // Try with different values
             //
             includeSubdirectories = false;
+            includeFileNames = false;
 
             directory = L"c:\\\\inetpub\\\\logs";
             filter = L"*.log";
@@ -380,7 +385,8 @@ namespace LogMonitorTests
                     configFileStrFormat.c_str(),
                     ReplaceAll(directory, L"\\", L"\\\\").c_str(),
                     filter.c_str(),
-                    includeSubdirectories ? L"true" : L"false"
+                    includeSubdirectories ? L"true" : L"false",
+                    includeFileNames ? L"true" : L"false"
                 );
 
                 JsonFileParser jsonParser(configFileStr);
@@ -407,6 +413,7 @@ namespace LogMonitorTests
                 Assert::AreEqual(directory.c_str(), sourceFile->Directory.c_str());
                 Assert::AreEqual(filter.c_str(), sourceFile->Filter.c_str());
                 Assert::AreEqual(includeSubdirectories, sourceFile->IncludeSubdirectories);
+                Assert::AreEqual(includeFileNames, sourceFile->IncludeFileNames);
             }
         }
 
@@ -460,6 +467,7 @@ namespace LogMonitorTests
                 Assert::AreEqual(directory.c_str(), sourceFile->Directory.c_str());
                 Assert::AreEqual(L"", sourceFile->Filter.c_str());
                 Assert::AreEqual(false, sourceFile->IncludeSubdirectories);
+                Assert::AreEqual(false, sourceFile->IncludeFileNames);
             }
         }
 

--- a/LogMonitor/LogMonitorTests/LogFileMonitorTests.cpp
+++ b/LogMonitor/LogMonitorTests/LogFileMonitorTests.cpp
@@ -202,7 +202,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -250,7 +250,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -314,11 +314,12 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
+            sourceFile.IncludeFileNames = true;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -421,7 +422,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -592,11 +593,12 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
+            sourceFile.IncludeFileNames = true;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -697,11 +699,12 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
+            sourceFile.IncludeFileNames = true;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -821,11 +824,12 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
+            sourceFile.IncludeFileNames = true;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -1011,11 +1015,12 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
+            sourceFile.IncludeFileNames = true;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //

--- a/LogMonitor/LogMonitorTests/LogFileMonitorTests.cpp
+++ b/LogMonitor/LogMonitorTests/LogFileMonitorTests.cpp
@@ -223,7 +223,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
-                Assert::AreEqual((TO_WSTR(content) + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find(TO_WSTR(content)) != std::wstring::npos);
             }
         }
 
@@ -283,7 +283,7 @@ namespace LogMonitorTests
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
                 output = RecoverOuput();
-                Assert::AreEqual((TO_WSTR(content) + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find((TO_WSTR(content) + L"\n").c_str()) == 0);
             }
         }
         
@@ -449,7 +449,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
-                Assert::AreEqual((content + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find(TO_WSTR(content)) != std::wstring::npos);
             }
 
             //
@@ -561,7 +561,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
-                Assert::AreEqual((TO_WSTR(content) + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find(TO_WSTR(content)) != std::wstring::npos);
             }
         }
 
@@ -626,8 +626,8 @@ namespace LogMonitorTests
                     Sleep(WAIT_TIME_LOGFILEMONITOR_AFTER_WRITE_SHORT);
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
-
-                Assert::AreEqual((TO_WSTR(content) + L"\n").c_str(), output.c_str());
+                
+                Assert::IsTrue(output.find(TO_WSTR(content)) != std::wstring::npos);
             }
 
             //
@@ -652,7 +652,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
-                Assert::AreEqual((TO_WSTR(content) + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find(TO_WSTR(content)) != std::wstring::npos);
             }
         }
 
@@ -729,7 +729,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
-                Assert::AreEqual((TO_WSTR(content) + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find(TO_WSTR(content)) != std::wstring::npos);
             }
 
             //
@@ -750,7 +750,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
-                Assert::AreEqual((TO_WSTR(content) + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find(TO_WSTR(content)) != std::wstring::npos);
             }
 
             //
@@ -777,7 +777,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
-                Assert::AreEqual((TO_WSTR(content)).c_str(), output.c_str());
+                Assert::IsTrue(output.find(TO_WSTR(content)) != std::wstring::npos);
             }
         }
 
@@ -858,7 +858,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
-                Assert::AreEqual((TO_WSTR(content) + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find(TO_WSTR(content)) != std::wstring::npos);
             }
 
             //
@@ -884,7 +884,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
-                Assert::AreEqual((TO_WSTR(content) + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find(TO_WSTR(content)) != std::wstring::npos);
             }
 
             //
@@ -910,7 +910,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
-                Assert::AreEqual((TO_WSTR(content) + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find(TO_WSTR(content)) != std::wstring::npos);
 
                 //
                 // Rename it with a filter-unmatching name.
@@ -1043,7 +1043,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
-                Assert::AreEqual((TO_WSTR(content) + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find(TO_WSTR(content)) != std::wstring::npos);
             }
 
             //
@@ -1085,7 +1085,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
-                Assert::AreEqual((TO_WSTR(content) + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find(TO_WSTR(content)) != std::wstring::npos);
             }
         }
     };

--- a/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
+++ b/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
@@ -261,10 +261,12 @@ ReadSourceAttributes(
             // * eventFormatMultiLine
             // * startAtOldestRecord
             // * includeSubdirectories
+            // * includeFileNames
             //
             else if (_wcsnicmp(key.c_str(), JSON_TAG_FORMAT_MULTILINE, _countof(JSON_TAG_FORMAT_MULTILINE)) == 0 ||
                      _wcsnicmp(key.c_str(), JSON_TAG_START_AT_OLDEST_RECORD, _countof(JSON_TAG_START_AT_OLDEST_RECORD)) == 0 ||
-                     _wcsnicmp(key.c_str(), JSON_TAG_INCLUDE_SUBDIRECTORIES, _countof(JSON_TAG_INCLUDE_SUBDIRECTORIES)) == 0)
+                     _wcsnicmp(key.c_str(), JSON_TAG_INCLUDE_SUBDIRECTORIES, _countof(JSON_TAG_INCLUDE_SUBDIRECTORIES)) == 0 ||
+                     _wcsnicmp(key.c_str(), JSON_TAG_INCLUDE_FILENAMES, _countof(JSON_TAG_INCLUDE_FILENAMES)) == 0)
             {
                 Attributes[key] = new bool{ Parser.ParseBooleanValue() };
             }
@@ -593,6 +595,7 @@ void _PrintSettings(_Out_ LoggerSettings& Config)
             std::wprintf(L"\t\tDirectory: %ls\n", sourceFile->Directory.c_str());
             std::wprintf(L"\t\tFilter: %ls\n", sourceFile->Filter.c_str());
             std::wprintf(L"\t\tIncludeSubdirectories: %ls\n", sourceFile->IncludeSubdirectories ? L"true" : L"false");
+            std::wprintf(L"\t\includeFileNames: %ls\n", sourceFile->IncludeFileNames ? L"true" : L"false");
             std::wprintf(L"\n");
 
             break;

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1641,7 +1641,7 @@ LogFileMonitor::ReadLogFile(
                 }
 
                 //
-                //log the name of the source log file
+                //log the name of the source log file if includeFileName field if true
                 //
                 if (m_includeFileNames)
                 {

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1651,7 +1651,6 @@ LogFileMonitor::ReadLogFile(
                         ).c_str());
                 }
                 
-
                 //
                 // Decode read string to UTF16, skipping the BOM if necessary.
                 //

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -39,11 +39,13 @@ using namespace std;
 ///
 LogFileMonitor::LogFileMonitor(_In_ const std::wstring& LogDirectory,
                                _In_ const std::wstring& Filter,
-                               _In_ bool IncludeSubfolders
+                               _In_ bool IncludeSubfolders,
+                               _In_ bool IncludeFileNames
                                ) :
                                m_logDirectory(LogDirectory),
                                m_filter(Filter),
-                               m_includeSubfolders(IncludeSubfolders)
+                               m_includeSubfolders(IncludeSubfolders),
+                               m_includeFileNames(IncludeFileNames)
 {
     m_stopEvent = NULL;
     m_overlappedEvent = NULL;
@@ -1641,10 +1643,14 @@ LogFileMonitor::ReadLogFile(
                 //
                 //log the name of the source log file
                 //
-                logWriter.WriteConsoleLog(
-                    Utility::FormatString(
-                        L"Log File: %ws", LogFileInfo->FileName.c_str()
-                    ).c_str());
+                if (m_includeFileNames)
+                {
+                    logWriter.WriteConsoleLog(
+                        Utility::FormatString(
+                            L"Log File: %ws", LogFileInfo->FileName.c_str()
+                        ).c_str());
+                }
+                
 
                 //
                 // Decode read string to UTF16, skipping the BOM if necessary.

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1560,7 +1560,7 @@ LogFileMonitor::ReadLogFile(
     std::wstring currentLineBuffer;
 
     //wprintf(L"ReadLogFile: File = %ws. bytesToRead = %d\n", LogFileInfo->FileName.c_str(), bytesToRead);
-
+    
     //
     // It's important to catch a posible error inside the loop, to at least print
     // the content of currentLineBuffer, if it has any.
@@ -1637,6 +1637,14 @@ LogFileMonitor::ReadLogFile(
                     //
                     foundBomSize = 0;
                 }
+
+                //
+                //log the name of the source log file
+                //
+                logWriter.WriteConsoleLog(
+                    Utility::FormatString(
+                        L"Log File: %ws", LogFileInfo->FileName.c_str()
+                    ).c_str());
 
                 //
                 // Decode read string to UTF16, skipping the BOM if necessary.

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1560,7 +1560,7 @@ LogFileMonitor::ReadLogFile(
     std::wstring currentLineBuffer;
 
     //wprintf(L"ReadLogFile: File = %ws. bytesToRead = %d\n", LogFileInfo->FileName.c_str(), bytesToRead);
- 
+
     //
     // It's important to catch a posible error inside the loop, to at least print
     // the content of currentLineBuffer, if it has any.

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1650,7 +1650,6 @@ LogFileMonitor::ReadLogFile(
                             L"Log File: %ws", LogFileInfo->FileName.c_str()
                         ).c_str());
                 }
-                
                 //
                 // Decode read string to UTF16, skipping the BOM if necessary.
                 //

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1560,7 +1560,7 @@ LogFileMonitor::ReadLogFile(
     std::wstring currentLineBuffer;
 
     //wprintf(L"ReadLogFile: File = %ws. bytesToRead = %d\n", LogFileInfo->FileName.c_str(), bytesToRead);
-    
+   
     //
     // It's important to catch a posible error inside the loop, to at least print
     // the content of currentLineBuffer, if it has any.

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1560,7 +1560,7 @@ LogFileMonitor::ReadLogFile(
     std::wstring currentLineBuffer;
 
     //wprintf(L"ReadLogFile: File = %ws. bytesToRead = %d\n", LogFileInfo->FileName.c_str(), bytesToRead);
-   
+ 
     //
     // It's important to catch a posible error inside the loop, to at least print
     // the content of currentLineBuffer, if it has any.

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.h
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.h
@@ -61,7 +61,8 @@ public:
     LogFileMonitor(
         _In_ const std::wstring& LogDirectory,
         _In_ const std::wstring& Filter,
-        _In_ bool IncludeSubfolders
+        _In_ bool IncludeSubfolders,
+        _In_ bool IncludeFileNames
         );
 
     ~LogFileMonitor();
@@ -75,6 +76,7 @@ private:
     std::wstring m_shortLogDirectory;
     std::wstring m_filter;
     bool m_includeSubfolders;
+    bool m_includeFileNames;
 
     //
     // Signaled by destructor to request the spawned thread to stop.

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -142,7 +142,7 @@ bool StartMonitors(_In_ const PWCHAR ConfigFileName)
 
                     try
                     {
-                        std::shared_ptr<LogFileMonitor> logfileMon = make_shared<LogFileMonitor>(sourceFile->Directory, sourceFile->Filter, sourceFile->IncludeSubdirectories);
+                        std::shared_ptr<LogFileMonitor> logfileMon = make_shared<LogFileMonitor>(sourceFile->Directory, sourceFile->Filter, sourceFile->IncludeSubdirectories, sourceFile->IncludeFileNames);
                         g_logfileMonitors.push_back(std::move(logfileMon));
                     }
                     catch (std::exception& ex)

--- a/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
+++ b/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
@@ -20,6 +20,7 @@
 #define JSON_TAG_DIRECTORY L"directory"
 #define JSON_TAG_FILTER L"filter"
 #define JSON_TAG_INCLUDE_SUBDIRECTORIES L"includeSubdirectories"
+#define JSON_TAG_INCLUDE_FILENAMES L"includeFileNames"
 #define JSON_TAG_PROVIDERS L"providers"
 
 ///
@@ -254,6 +255,7 @@ public:
     std::wstring Directory;
     std::wstring Filter;
     bool IncludeSubdirectories = false;
+    bool IncludeFileNames = false;
 
     static bool Unwrap(
         _In_ AttributesMap& Attributes,
@@ -291,6 +293,15 @@ public:
             && Attributes[JSON_TAG_INCLUDE_SUBDIRECTORIES] != nullptr)
         {
             NewSource.IncludeSubdirectories = *(bool*)Attributes[JSON_TAG_INCLUDE_SUBDIRECTORIES];
+        }
+
+        //
+        // includeFileNames is an optional value
+        //
+        if (Attributes.find(JSON_TAG_INCLUDE_FILENAMES) != Attributes.end()
+            && Attributes[JSON_TAG_INCLUDE_FILENAMES] != nullptr)
+        {
+            NewSource.IncludeFileNames = *(bool*)Attributes[JSON_TAG_INCLUDE_FILENAMES];
         }
 
         return true;

--- a/LogMonitor/src/LogMonitor/sample-config-files/IIS/LogMonitorConfig.json
+++ b/LogMonitor/src/LogMonitor/sample-config-files/IIS/LogMonitorConfig.json
@@ -20,7 +20,8 @@
         "type": "File",
         "directory": "c:\\inetpub\\logs",
         "filter": "*.log",
-        "includeSubdirectories": true
+        "includeSubdirectories": true,
+        "includeFileNames": false
       },
       {
         "type": "ETW",


### PR DESCRIPTION
**Summary**

The log file messages only contain the contents of the log files with no indication of the source of the content. This makes it hard to know where these messages are coming from. (Issue: #23 )

Some changes are required to include the file names when displaying contents of log files.
In the case of event logs, the message source is indicated in the _Channel_ tag (application / system):

    `std::wstring formattedEvent = Utility::FormatString(
                                                            L"<Source>EventLog</Source><Time>%s</Time><LogEntry><Channel>%s</Channel><Level>%s</Level><EventId>%u</EventId><Message>%s</Message></LogEntry>",
                                                            Utility::FileTimeToString(fileTimeCreated).c_str(),
                                                            channelName.c_str(),
                                                            c_LevelToString[static_cast<UINT8>(level)].c_str(),
                                                            eventId,
                                                            (LPWSTR)(&m_eventMessageBuffer[0]));`


Screenshot of event log output
![image](https://user-images.githubusercontent.com/28774968/177988450-af467302-550a-4822-b426-a41853a9851d.png)




**Solution / Change Implementation**
1. Add a setting (in LogMonitorConfig.json) to either have the filename included or not since some people may not need it.
2. Check the 'includeFileNames' field configuration before showing the content of the file and only display the file name (log source) if 'includeFileNames' is set as true..
3. Change the unit tests to check if the message displayed to stdout contains the log file content provided, instead of checking if they are equal _(since the message displayed to stdout will now contain the log file name)_
4. Add two more unit tests to: 
    - [ ] Confirm that if the 'IncludeFileNames' configuration field is set to true, the LogFileMonitor prints the file name
    - [ ] Confirm that if the 'IncludeFileNames' configuration  field is set to false, the LogFileMonitor does not print the file name


