### PR TITLE
Handle ERROR_EVT_UNRESOLVED_VALUE_INSERT

### DIFF
--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -441,6 +441,11 @@ EventMonitor::PrintEvent(
             status = ERROR_SUCCESS;
         }
 
+        if (ERROR_EVT_UNRESOLVED_VALUE_INSERT == GetLastError())
+        {
+            status = ERROR_SUCCESS;
+        }
+
         if (status == ERROR_SUCCESS)
         {
             //
@@ -488,6 +493,11 @@ EventMonitor::PrintEvent(
                 if (status != ERROR_EVT_MESSAGE_NOT_FOUND)
                 {
                     if (ERROR_INSUFFICIENT_BUFFER == status)
+                    {
+                        status = ERROR_SUCCESS;
+                    }
+
+                    if (ERROR_EVT_UNRESOLVED_VALUE_INSERT == status)
                     {
                         status = ERROR_SUCCESS;
                     }

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -436,7 +436,8 @@ EventMonitor::PrintEvent(
             status = ERROR_INVALID_HANDLE;
         }
 
-        if (ERROR_INSUFFICIENT_BUFFER == (status = GetLastError()))
+        status = GetLastError();
+        if (ERROR_INSUFFICIENT_BUFFER == status || ERROR_EVT_UNRESOLVED_VALUE_INSERT == status)
         {
             status = ERROR_SUCCESS;
         }

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -436,7 +436,7 @@ EventMonitor::PrintEvent(
             status = ERROR_INVALID_HANDLE;
         }
 
-        if (ERROR_INSUFFICIENT_BUFFER == (status = GetLastError()) || ERROR_EVT_UNRESOLVED_VALUE_INSERT == status)
+        if (ERROR_INSUFFICIENT_BUFFER == (status = GetLastError()))
         {
             status = ERROR_SUCCESS;
         }
@@ -512,7 +512,7 @@ EventMonitor::PrintEvent(
             if (status == ERROR_SUCCESS)
             {
                 std::wstring formattedEvent = Utility::FormatString(
-                                                        L"<Source>EventLog</Source><Time>%s</Time><LogEntry><Channel>%s</Channel><Level>%s</Level><EventId>%u</EventId><Message>%s</Message></LogEntry>",
+                                                        L"<Source>EventLog</Source><Time>%1%s</Time><LogEntry><Channel>%s</Channel><Level>%s</Level><EventId>%u</EventId><Message>%s</Message></LogEntry>",
                                                         Utility::FileTimeToString(fileTimeCreated).c_str(),
                                                         channelName.c_str(),
                                                         c_LevelToString[static_cast<UINT8>(level)].c_str(),

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -512,7 +512,7 @@ EventMonitor::PrintEvent(
             if (status == ERROR_SUCCESS)
             {
                 std::wstring formattedEvent = Utility::FormatString(
-                                                        L"<Source>EventLog</Source><Time>%1%s</Time><LogEntry><Channel>%s</Channel><Level>%s</Level><EventId>%u</EventId><Message>%s</Message></LogEntry>",
+                                                        L"<Source>EventLog</Source><Time>%s</Time><LogEntry><Channel>%s</Channel><Level>%s</Level><EventId>%u</EventId><Message>%s</Message></LogEntry>",
                                                         Utility::FileTimeToString(fileTimeCreated).c_str(),
                                                         channelName.c_str(),
                                                         c_LevelToString[static_cast<UINT8>(level)].c_str(),

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -436,12 +436,7 @@ EventMonitor::PrintEvent(
             status = ERROR_INVALID_HANDLE;
         }
 
-        if (ERROR_INSUFFICIENT_BUFFER == (status = GetLastError()))
-        {
-            status = ERROR_SUCCESS;
-        }
-
-        if (ERROR_EVT_UNRESOLVED_VALUE_INSERT == GetLastError())
+        if (ERROR_INSUFFICIENT_BUFFER == (status = GetLastError()) || ERROR_EVT_UNRESOLVED_VALUE_INSERT == status)
         {
             status = ERROR_SUCCESS;
         }
@@ -492,12 +487,7 @@ EventMonitor::PrintEvent(
 
                 if (status != ERROR_EVT_MESSAGE_NOT_FOUND)
                 {
-                    if (ERROR_INSUFFICIENT_BUFFER == status)
-                    {
-                        status = ERROR_SUCCESS;
-                    }
-
-                    if (ERROR_EVT_UNRESOLVED_VALUE_INSERT == status)
+                    if (ERROR_INSUFFICIENT_BUFFER == status || ERROR_EVT_UNRESOLVED_VALUE_INSERT == status)
                     {
                         status = ERROR_SUCCESS;
                     }


### PR DESCRIPTION
'ERROR: Failed to query next event' is displayed when a remote procedure call is cancelled after the GetLastError() function returns ERROR_EVT_UNRESOLVED_VALUE_INSERT. 

This error is captured when a windows event log message contains a %n where n is a number (for example, %1 or %3) in the event description and n is not substituted, the event viewer treats it as an insertion string. 

When this kind of event comes into the probe, the probe will try to retrieve the actual value of %1 or %3. If it can not, it will give the error and leave Summary field as blank

### **Solution:**

Similar to ERROR_INSUFFICIENT_BUFFER, the ERROR_EVT_UNRESOLVED_VALUE_INSERT should not be handled as an error.
</br>
_Useful link: https://www.ibm.com/support/pages/apar/IV67708_