### PR TITLE
Refactor StartMonitors

### DIFF
--- a/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
+++ b/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
@@ -1523,5 +1523,13 @@ namespace LogMonitorTests
                 Assert::IsTrue(output.find(L"WARNING") != std::wstring::npos);
             }
         }
+
+        TEST_METHOD(TestConfigFileReading)
+        {
+            PWCHAR configFileName = (PWCHAR)DEFAULT_CONFIG_FILENAME;
+            bool succcess = OpenConfigFile(configFileName);
+
+            Assert::AreEqual(succcess, true);
+        }
     };
 }

--- a/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
+++ b/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
@@ -71,31 +71,6 @@ namespace LogMonitorTests
         ///
         std::vector<std::wstring> directoriesToDeleteAtCleanup;
 
-       ///
-       /// Creates a new random-name directory inside the Temp directory. 
-       ///
-       /// \return The new directory path. If an error occurs, it's empty.
-       ///
-        std::wstring CreateTempDirectory()
-        {
-            WCHAR tempDirectory[L_tmpnam_s];
-            ZeroMemory(tempDirectory, sizeof(tempDirectory));
-
-            errno_t err = _wtmpnam_s(tempDirectory, L_tmpnam_s);
-            if (err)
-            {
-                return L"";
-            }
-
-            long status = CreateDirectoryW(tempDirectory, NULL);
-            if (status == 0)
-            {
-                return L"";
-            }
-
-            return std::wstring(tempDirectory);
-        }
-
     public:
 
         ///

--- a/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
+++ b/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
@@ -1524,33 +1524,5 @@ namespace LogMonitorTests
             }
         }
 
-        TEST_METHOD(TestUTF8EncodedConfigFileReading)
-        {
-            std::wstring filename = L"C:\\LogMonitor\\LogMonitorConfigTesting.json";
-            std::wstring configFileStr =
-                Utility::FormatString(L"$var = @\"\n{    \
-                    \"LogConfig\": {    \
-                        \"sources\": [ \
-                            {\
-                                \"type\": \"ETW\",\
-                                \"providers\" : [\
-                                    {\
-                                        \"providerGuid\": \"305FC87B-002A-5E26-D297-60223012CA9C\",\
-                                        \"level\": \"Info\"\
-                                    }\
-                                ]\
-                            }\
-                        ]\
-                    }\
-                }\
-                \n\"@\
-                \n$var | powershell Out-File -FilePath \"%s\" -Encoding utf8", filename.c_str());
-
-            int status = _wsystem(configFileStr.c_str());
-            Assert::AreEqual(status, 0);
-
-            bool succcess = OpenConfigFile((PWCHAR)filename.c_str());
-            Assert::AreEqual(succcess, true);
-        }
     };
 }

--- a/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
+++ b/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
@@ -1524,5 +1524,43 @@ namespace LogMonitorTests
             }
         }
 
+        ///
+        /// Check that UTF8 encoded config file is opened and read by OpenConfigFile.
+        ///
+        TEST_METHOD(TestUTF8EncodedConfigFileReading)
+        {
+            std::wstring folderName = L"D:\\LogMonitor";
+            std::wstring fileName = L"LogMonitorConfigTesting.json";
+            std::wstring fullFilePath = folderName + L"\\" + fileName;
+
+            //create a temp folder to hold config file
+            int createFolder = _wsystem(Utility::FormatString(L"mkdir %s", folderName.c_str()).c_str());
+            Assert::AreEqual(createFolder, 0);
+
+            //create the utf8 encoded config file
+            std::wstring configFileStr =
+                L"{    \
+                    \"LogConfig\": {    \
+                        \"sources\": [ \
+                        ]\
+                    }\
+                }";
+
+            std::wofstream wof;
+            wof.imbue(std::locale(std::locale::empty(), new std::codecvt_utf8<wchar_t, 0x10ffff, std::generate_header>));
+            wof.open(fullFilePath);
+            wof << configFileStr;
+            wof.close();
+
+            //check if the file can be successfully read by OpenConfigFile
+            LoggerSettings settings;
+            bool succcess = OpenConfigFile((PWCHAR)fullFilePath.c_str(), settings);
+            Assert::AreEqual(succcess, true);
+
+            //clean up
+            _wsystem(Utility::FormatString(L"del /f /s /q %s 1>nul", folderName.c_str()).c_str());
+            Assert::AreEqual(_wsystem(Utility::FormatString(L"rmdir /s /q %s", folderName.c_str()).c_str()), 0);
+        }
+
     };
 }

--- a/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
+++ b/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
@@ -1524,11 +1524,32 @@ namespace LogMonitorTests
             }
         }
 
-        TEST_METHOD(TestConfigFileReading)
+        TEST_METHOD(TestUTF8EncodedConfigFileReading)
         {
-            PWCHAR configFileName = (PWCHAR)DEFAULT_CONFIG_FILENAME;
-            bool succcess = OpenConfigFile(configFileName);
+            std::wstring filename = L"C:\\LogMonitor\\LogMonitorConfigTesting.json";
+            std::wstring configFileStr =
+                Utility::FormatString(L"$var = @\"\n{    \
+                    \"LogConfig\": {    \
+                        \"sources\": [ \
+                            {\
+                                \"type\": \"ETW\",\
+                                \"providers\" : [\
+                                    {\
+                                        \"providerGuid\": \"305FC87B-002A-5E26-D297-60223012CA9C\",\
+                                        \"level\": \"Info\"\
+                                    }\
+                                ]\
+                            }\
+                        ]\
+                    }\
+                }\
+                \n\"@\
+                \n$var | powershell Out-File -FilePath \"%s\" -Encoding utf8", filename.c_str());
 
+            int status = _wsystem(configFileStr.c_str());
+            Assert::AreEqual(status, 0);
+
+            bool succcess = OpenConfigFile((PWCHAR)filename.c_str());
             Assert::AreEqual(succcess, true);
         }
     };

--- a/LogMonitor/LogMonitorTests/LogFileMonitorTests.cpp
+++ b/LogMonitor/LogMonitorTests/LogFileMonitorTests.cpp
@@ -47,32 +47,6 @@ namespace LogMonitorTests
             return std::wstring(bigOutBuf);
         }
 
-
-        ///
-        /// Creates a new random-name directory inside the Temp directory. 
-        ///
-        /// \return The new directory path. If an error occurs, it's empty.
-        ///
-        std::wstring CreateTempDirectory()
-        {
-            WCHAR tempDirectory[L_tmpnam_s];
-            ZeroMemory(tempDirectory, sizeof(tempDirectory));
-
-            errno_t err = _wtmpnam_s(tempDirectory, L_tmpnam_s);
-            if (err)
-            {
-                return L"";
-            }
-
-            long status = CreateDirectoryW(tempDirectory, NULL);
-            if (status == 0)
-            {
-                return L"";
-            }
-
-            return std::wstring(tempDirectory);
-        }
-
         ///
         /// Writes to a new or existing file. 
         ///

--- a/LogMonitor/LogMonitorTests/LogMonitorTests.vcxproj
+++ b/LogMonitor/LogMonitorTests/LogMonitorTests.vcxproj
@@ -175,6 +175,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="ConfigFileParserTests.cpp" />
+    <ClCompile Include="Utility.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/LogMonitor/LogMonitorTests/LogMonitorTests.vcxproj.filters
+++ b/LogMonitor/LogMonitorTests/LogMonitorTests.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="EtwMonitorTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Utility.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">

--- a/LogMonitor/LogMonitorTests/Utility.cpp
+++ b/LogMonitor/LogMonitorTests/Utility.cpp
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+#include "pch.h"
+
+using namespace std;
+
+///
+/// Utility.cpp
+///
+/// Contains utility functions that are used across the tests
+///
+
+///
+/// Creates a new random-name directory inside the Temp directory. 
+///
+/// \return The new directory path. If an error occurs, it's empty.
+///
+wstring CreateTempDirectory()
+{
+    WCHAR tempDirectory[L_tmpnam_s];
+    ZeroMemory(tempDirectory, sizeof(tempDirectory));
+
+    errno_t err = _wtmpnam_s(tempDirectory, L_tmpnam_s);
+    if (err)
+    {
+        return L"";
+    }
+
+    long status = CreateDirectoryW(tempDirectory, NULL);
+    if (status == 0)
+    {
+        return L"";
+    }
+
+    return wstring(tempDirectory);
+}

--- a/LogMonitor/LogMonitorTests/Utility.h
+++ b/LogMonitor/LogMonitorTests/Utility.h
@@ -1,4 +1,3 @@
 #pragma once
 
 std::wstring CreateTempDirectory();
-std::wstring RecoverOuput();

--- a/LogMonitor/LogMonitorTests/Utility.h
+++ b/LogMonitor/LogMonitorTests/Utility.h
@@ -1,0 +1,4 @@
+#pragma once
+
+std::wstring CreateTempDirectory();
+std::wstring RecoverOuput();

--- a/LogMonitor/LogMonitorTests/pch.h
+++ b/LogMonitor/LogMonitorTests/pch.h
@@ -61,4 +61,5 @@
 #include "../src/LogMonitor/EventMonitor.h"
 #include "../src/LogMonitor/LogFileMonitor.h"
 #include "../src/LogMonitor/ProcessMonitor.h"
+#include "Utility.h"
 #endif //PCH_H

--- a/LogMonitor/LogMonitorTests/pch.h
+++ b/LogMonitor/LogMonitorTests/pch.h
@@ -47,6 +47,7 @@
 #include <fstream>
 #include <streambuf>
 #include <system_error>
+#include <codecvt>
 #include "shlwapi.h"
 #include <io.h> 
 #include <fcntl.h> 

--- a/LogMonitor/LogMonitorTests/pch.h
+++ b/LogMonitor/LogMonitorTests/pch.h
@@ -49,6 +49,7 @@
 #include <system_error>
 #include <codecvt>
 #include "shlwapi.h"
+#include <direct.h >
 #include <io.h> 
 #include <fcntl.h> 
 #include "../src/LogMonitor/Utility.h"

--- a/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
+++ b/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
@@ -22,7 +22,7 @@
 ///
 /// \return True if the configuration file was valid. Otherwise false
 ///
-bool OpenConfigFile(_In_ const PWCHAR ConfigFileName, _In_ LoggerSettings& Config)
+bool OpenConfigFile(_In_ const PWCHAR ConfigFileName, _Out_ LoggerSettings& Config)
 {
     bool success;
     std::wifstream configFileStream(ConfigFileName);

--- a/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
+++ b/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
@@ -7,16 +7,21 @@
 #include "./Parser/ConfigFileParser.h"
 #include "./LogWriter.h"
 
-using namespace std;
-
 /// ConfigFileParser.cpp
 ///
 /// Reads the configuration file content (as a string), parsing it with a
 /// JsonFileParser object previously created.
 ///
-/// The main entry point in this file is ReadConfigFile.
+/// The main entry point in this file is OpenConfigFile.
 ///
 
+///
+/// Open the config file and convert the document content into json
+///
+/// \param FileName       Config File name.
+///
+/// \return True if the configuration file was valid. Otherwise false
+///
 bool OpenConfigFile(_In_ const PWCHAR ConfigFileName)
 {
     bool success;

--- a/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
+++ b/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
@@ -22,7 +22,7 @@
 ///
 /// \return True if the configuration file was valid. Otherwise false
 ///
-bool OpenConfigFile(_In_ const PWCHAR ConfigFileName, _Out_ LoggerSettings& Config)
+bool OpenConfigFile(_In_ const PWCHAR ConfigFileName, _In_ LoggerSettings& Config)
 {
     bool success;
     std::wifstream configFileStream(ConfigFileName);

--- a/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
+++ b/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
@@ -22,7 +22,7 @@
 ///
 /// \return True if the configuration file was valid. Otherwise false
 ///
-bool OpenConfigFile(_In_ const PWCHAR ConfigFileName)
+bool OpenConfigFile(_In_ const PWCHAR ConfigFileName, _Out_ LoggerSettings& Config)
 {
     bool success;
     std::wifstream configFileStream(ConfigFileName);
@@ -31,8 +31,6 @@ bool OpenConfigFile(_In_ const PWCHAR ConfigFileName)
 
     if (configFileStream.is_open())
     {
-        LoggerSettings settings;
-
         try
         {
             //
@@ -44,7 +42,7 @@ bool OpenConfigFile(_In_ const PWCHAR ConfigFileName)
 
             JsonFileParser jsonParser(configFileStr);
 
-            success = ReadConfigFile(jsonParser, settings);
+            success = ReadConfigFile(jsonParser, Config);
         }
         catch (std::exception& ex)
         {
@@ -60,9 +58,7 @@ bool OpenConfigFile(_In_ const PWCHAR ConfigFileName)
             );
             success = false;
         }
-
-    }
-    else {
+    } else {
         logWriter.TraceError(
             Utility::FormatString(
                 L"Configuration file '%s' not found. Logs will not be monitored.",

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -77,58 +77,6 @@ void PrintUsage()
     wprintf(L"\tfile.\n\n");
 }
 
-bool OpenandReadConfigFile(_In_ const PWCHAR ConfigFileName)
-{
-    bool success;
-    std::wifstream configFileStream(ConfigFileName);
-    configFileStream.imbue(std::locale(configFileStream.getloc(),
-        new std::codecvt_utf8_utf16<wchar_t, 0x10ffff, std::little_endian>));
-
-    if (configFileStream.is_open())
-    {
-        LoggerSettings settings;
-
-        try
-        {
-            //
-            // Convert the document content to a string, to pass it to JsonFileParser constructor.
-            //
-            std::wstring configFileStr((std::istreambuf_iterator<wchar_t>(configFileStream)),
-                std::istreambuf_iterator<wchar_t>());
-            configFileStr.erase(remove(configFileStr.begin(), configFileStr.end(), 0xFEFF), configFileStr.end());
-
-            JsonFileParser jsonParser(configFileStr);
-
-            success = ReadConfigFile(jsonParser, settings);
-        }
-        catch (std::exception& ex)
-        {
-            logWriter.TraceError(
-                Utility::FormatString(L"Failed to read json configuration file. %S", ex.what()).c_str()
-            );
-            success = false;
-        }
-        catch (...)
-        {
-            logWriter.TraceError(
-                Utility::FormatString(L"Failed to read json configuration file. Unknown error occurred.").c_str()
-            );
-            success = false;
-        }
-
-    } else {
-        logWriter.TraceError(
-            Utility::FormatString(
-                L"Configuration file '%s' not found. Logs will not be monitored.",
-                ConfigFileName
-            ).c_str()
-        );
-        success = false;
-    }
-
-    return success;
-}
-
 void StartMonitors()
 {
     std::vector<EventLogChannel> eventChannels;
@@ -292,7 +240,7 @@ int __cdecl wmain(int argc, WCHAR *argv[])
     }
 
     //read the config file
-    bool configFileReadSuccess = OpenandReadConfigFile(configFileName);
+    bool configFileReadSuccess = OpenConfigFile(configFileName);
 
     //start the monitors
     if (configFileReadSuccess)

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -77,15 +77,13 @@ void PrintUsage()
     wprintf(L"\tfile.\n\n");
 }
 
-void StartMonitors()
+void StartMonitors(_Out_ LoggerSettings& settings)
 {
     std::vector<EventLogChannel> eventChannels;
     std::vector<ETWProvider> etwProviders;
     bool eventMonMultiLine;
     bool eventMonStartAtOldestRecord;
     bool etwMonMultiLine;
-
-    LoggerSettings settings;
 
     for (auto source : settings.Sources)
     {
@@ -239,13 +237,14 @@ int __cdecl wmain(int argc, WCHAR *argv[])
         }
     }
 
+    LoggerSettings settings;
     //read the config file
-    bool configFileReadSuccess = OpenConfigFile(configFileName);
+    bool configFileReadSuccess = OpenConfigFile(configFileName, settings);
 
     //start the monitors
     if (configFileReadSuccess)
     {
-        StartMonitors();
+        StartMonitors(settings);
     } else {
         logWriter.TraceError(L"Invalid configuration file.");
     }

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -132,7 +132,8 @@ void StartMonitors(_Out_ LoggerSettings& settings)
                 {
                     logWriter.TraceError(
                         Utility::FormatString(
-                            L"Instantiation of a LogFileMonitor object failed for directory %ws. Unknown error occurred.",
+                            L"Instantiation of a LogFileMonitor object failed for directory %ws. \
+                                Unknown error occurred.",
                             sourceFile->Directory.c_str()
                         ).c_str()
                     );

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -77,7 +77,7 @@ void PrintUsage()
     wprintf(L"\tfile.\n\n");
 }
 
-void StartMonitors(_Out_ LoggerSettings& settings)
+void StartMonitors(_In_ LoggerSettings& settings)
 {
     std::vector<EventLogChannel> eventChannels;
     std::vector<ETWProvider> etwProviders;

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -132,8 +132,7 @@ void StartMonitors(_Out_ LoggerSettings& settings)
                 {
                     logWriter.TraceError(
                         Utility::FormatString(
-                            L"Instantiation of a LogFileMonitor object failed for directory %ws. \
-                                Unknown error occurred.",
+                            L"Instantiation of a LogFileMonitor object failed for directory %ws. Unknown error occurred.",
                             sourceFile->Directory.c_str()
                         ).c_str()
                     );

--- a/LogMonitor/src/LogMonitor/Parser/ConfigFileParser.h
+++ b/LogMonitor/src/LogMonitor/Parser/ConfigFileParser.h
@@ -14,7 +14,8 @@
 #include <variant>
 
 bool OpenConfigFile(
-    _In_ const PWCHAR ConfigFileName
+    _In_ const PWCHAR ConfigFileName,
+    _Out_ LoggerSettings& Config
 );
 
 bool ReadConfigFile(

--- a/LogMonitor/src/LogMonitor/Parser/ConfigFileParser.h
+++ b/LogMonitor/src/LogMonitor/Parser/ConfigFileParser.h
@@ -15,7 +15,7 @@
 
 bool OpenConfigFile(
     _In_ const PWCHAR ConfigFileName,
-    _In_ LoggerSettings& Config
+    _Out_ LoggerSettings& Config
 );
 
 bool ReadConfigFile(

--- a/LogMonitor/src/LogMonitor/Parser/ConfigFileParser.h
+++ b/LogMonitor/src/LogMonitor/Parser/ConfigFileParser.h
@@ -15,7 +15,7 @@
 
 bool OpenConfigFile(
     _In_ const PWCHAR ConfigFileName,
-    _Out_ LoggerSettings& Config
+    _In_ LoggerSettings& Config
 );
 
 bool ReadConfigFile(

--- a/LogMonitor/src/LogMonitor/Parser/ConfigFileParser.h
+++ b/LogMonitor/src/LogMonitor/Parser/ConfigFileParser.h
@@ -18,6 +18,10 @@ bool ReadConfigFile(
     _Out_ LoggerSettings& Config
 );
 
+bool OpenConfigFile(
+    _In_ const PWCHAR ConfigFileName
+);
+
 bool ReadLogConfigObject(
     _In_ JsonFileParser& Parser,
     _Out_ LoggerSettings& Config

--- a/LogMonitor/src/LogMonitor/Parser/ConfigFileParser.h
+++ b/LogMonitor/src/LogMonitor/Parser/ConfigFileParser.h
@@ -13,13 +13,13 @@
 #include <memory>
 #include <variant>
 
+bool OpenConfigFile(
+    _In_ const PWCHAR ConfigFileName
+);
+
 bool ReadConfigFile(
     _In_ JsonFileParser& Parser,
     _Out_ LoggerSettings& Config
-);
-
-bool OpenConfigFile(
-    _In_ const PWCHAR ConfigFileName
 );
 
 bool ReadLogConfigObject(


### PR DESCRIPTION
Currently, the logic to read and convert the config file is part of the StartMonitors function.

![image](https://user-images.githubusercontent.com/28774968/184959689-a1426560-7eae-46a4-93ce-fd3a4126ae98.png)


The config file reading should be separated from the Monitor function and unit tests created to test the new function.