### PR TITLE
Refactored from using obsolete EnableTrace to EnableTraceEx2 function

### DIFF
--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -561,34 +561,28 @@ EtwMonitor::StartTraceSession(
                 switch (status)
                 {
                 case ERROR_INVALID_PARAMETER:
-                    logWriter.TraceWarning(L"The ProviderId id NULL or the TraceHandle is 0.");
+                    logWriter.TraceError(L"The ProviderId id NULL or the TraceHandle is 0.");
                     break;
                 case ERROR_TIMEOUT:
-                    logWriter.TraceWarning(L"The timeout value expired before the enable callback completed.");
+                    logWriter.TraceError(L"The timeout value expired before the enable callback completed.");
                     break;
                 case ERROR_INVALID_FUNCTION:
-                    logWriter.TraceWarning(L"You cannot update the level when the provider is not registered.");
+                    logWriter.TraceError(L"You cannot update the level when the provider is not registered.");
                     break;
                 case ERROR_NO_SYSTEM_RESOURCES:
-                    logWriter.TraceWarning(L"Exceeded the number of ETW trace sessions that the provider can enable.");
+                    logWriter.TraceError(L"Exceeded the number of ETW trace sessions that the provider can enable.");
                     break;
                 case ERROR_ACCESS_DENIED:
-                    logWriter.TraceWarning(L"Only users with administrative privileges can enable event providers to a cross-process session.");
+                    logWriter.TraceError(L"Only users with administrative privileges can enable event providers to a cross-process session.");
                     break;
                 default:
+                    logWriter.TraceError(
+                        Utility::FormatString(L"An unknown error occurred: %lu", status).c_str()
+                    );
                     break;
                 }
 
                 return status;
-                // {
-                //     logWriter.TraceWarning(L"The ProviderId id NULL or the TraceHandle is 0.");
-                //     return status;
-                // }
-
-                {
-                    logWriter.TraceWarning(L"Only users with administrative privileges can enable event providers to a cross-process session.");
-                    return status;
-                }
             }
         }
     }

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -15,7 +15,7 @@ using namespace std;
 ///
 /// EventMonitor starts a monitor thread that waits for events from EvtSubscribe
 /// or for a stop event to be set. The same thread processes the changes and invokes the callback.
-/// Note: The constructor blocks until the spwaned thread starts listening for changes or dies.
+/// Note: The constructor blocks until the spawned thread starts listening for changes or dies.
 ///
 /// The destructor signals the stop event and waits up to MONITOR_THREAD_EXIT_MAX_WAIT_MILLIS for the monitoring
 /// thread to exit. To prevent the thread from out-living EventMonitor, the destructor fails fast
@@ -97,7 +97,7 @@ EventMonitor::~EventMonitor()
 /// \param Context Callback context to the event monitor thread.
 ///                It's EventMonitor object that started this thread.
 ///
-/// \return Status of event monitoring opeartion.
+/// \return Status of event monitoring operation.
 ///
 DWORD
 EventMonitor::StartEventMonitorStatic(
@@ -138,7 +138,7 @@ EventMonitor::StartEventMonitorStatic(
 /// or for events to be arrived. When new events are arrived, it invokes the callback, resets,
 /// and starts the wait again.
 ///
-/// \return Status of event monitoring opeartion.
+/// \return Status of event monitoring operation.
 ///
 DWORD
 EventMonitor::StartEventMonitor()
@@ -324,7 +324,7 @@ EventMonitor::ConstructWindowsEventQuery(
 ///
 /// \param EventChannels         The handle to the subscription that EvtSubscribe function returned.
 ///
-/// \return A DWORD with a windows error value. If the function succeded, it returns
+/// \return A DWORD with a windows error value. If the function succeeded, it returns
 ///     ERROR_SUCCESS.
 ///
 DWORD
@@ -648,7 +648,7 @@ EventMonitor::EnableEventLogChannel(
         &dwPropValSize))
     {
         //
-        // Return if event channel is slready enabled.
+        // Return if event channel is already enabled.
         //
         if (propValue.BooleanVal)
         {


### PR DESCRIPTION
A trace session controller calls EnableTrace to configure how an ETW event provider logs events to a trace session.


[EnableTrace](https://docs.microsoft.com/en-us/windows/win32/api/evntrace/nf-evntrace-enabletrace) function is obsolete. The [EnableTraceEx2](https://docs.microsoft.com/en-us/windows/desktop/ETW/enabletraceex2) function supersedes this function.

How to refactor : https://docs.microsoft.com/en-us/windows/win32/api/evntrace/nf-evntrace-enabletrace#:~:text=This%20function%20is%20obsolete.%20For,the%20documentation%20for%20EnableTraceEx2.