### PR TITLE
Refactored StopTrace function to ControlTrace function

### DIFF
--- a/LogMonitor/src/LogMonitor/EtwMonitor.h
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.h
@@ -27,13 +27,13 @@ private:
 
     std::vector<ETWProvider> m_providersConfig;
     bool m_eventFormatMultiLine;
-    TRACEHANDLE  m_startTraceHandle;
+    TRACEHANDLE m_startTraceHandle;
 
     //
     // Vectors used to store an EVENT_TRACE_PROPERTIES object.
     //
-    std::vector<BYTE>    m_vecEventTracePropsBuffer;
-    std::vector<BYTE>    m_vecStopTracePropsBuffer;
+    std::vector<BYTE> m_vecEventTracePropsBuffer;
+    std::vector<BYTE> m_vecStopTracePropsBuffer;
 
     //
     // Signaled by destructor to request ProcessTrace to stop.


### PR DESCRIPTION
The StopTrace function stops the specified event tracing session.

This function is obsolete. Instead, use ControlTrace with ControlCode set to EVENT_TRACE_CONTROL_STOP. The [ControlTrace](https://docs.microsoft.com/en-us/windows/win32/api/evntrace/nf-evntrace-controltracew) function supersedes this function.