### PR TITLE
fix process monitors utf8 character encoding support

### DIFF
--- a/LogMonitor/src/LogMonitor/LogWriter.h
+++ b/LogMonitor/src/LogMonitor/LogWriter.h
@@ -51,7 +51,7 @@ public :
 
         AcquireSRWLockExclusive(&m_stdoutLock);
 
-        result = WriteFile(FileHandle, Buffer, NumberOfBytesToWrite, NumberOfBytesWritten, Overlapped);
+        result = WriteConsoleA(FileHandle, Buffer, NumberOfBytesToWrite, NumberOfBytesWritten, Overlapped);
 
         ReleaseSRWLockExclusive(&m_stdoutLock);
 


### PR DESCRIPTION
-  replaced WriteFile with WriteConsoleA to support utf8 encoded char buffer 