### PR TITLE
fix: stderr and stdout mixup from child process

### DIFF
--- a/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
@@ -102,7 +102,7 @@ DWORD CreateChildProcess(std::wstring& Cmdline)
     //
     ZeroMemory(&siStartInfo, sizeof(STARTUPINFO));
     siStartInfo.cb = sizeof(STARTUPINFO);
-    siStartInfo.hStdError = GetStdHandle(STD_ERROR_HANDLE);;
+    siStartInfo.hStdError = g_hChildStd_OUT_Wr; // redirect errors too to avoid log interleaving
     siStartInfo.hStdOutput = g_hChildStd_OUT_Wr;
     siStartInfo.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
     siStartInfo.dwFlags |= STARTF_USESTDHANDLES;


### PR DESCRIPTION
Make child process use same handle for `stdout` and `stderr` to avoid log mixup:

![image](https://user-images.githubusercontent.com/261265/197700682-0a7fd05d-46e8-4d4b-a23a-b06c59edd799.png)

ref: https://learn.microsoft.com/en-us/windows/win32/procthread/creating-a-child-process-with-redirected-input-and-output
