### PR TITLE
fix: file monitor source tagging skips some log lines

### DIFF
--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1615,7 +1615,6 @@ LogFileMonitor::ReadLogFile(
                                 decodedString.begin() + found
                             );
                             LogFileMonitor::WriteToConsole(currentLineBuffer, LogFileInfo->FileName);
-                            
                         }
                         catch (...)
                         {

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1614,17 +1614,18 @@ LogFileMonitor::ReadLogFile(
                                 decodedString.begin(),
                                 decodedString.begin() + found
                             );
-                            logWriter.WriteConsoleLog(fileName + currentLineBuffer);
+                            LogFileMonitor::WriteToConsole(currentLineBuffer, LogFileInfo->FileName);
+                            
                         }
                         catch (...)
                         {
                             //
                             // If insert failed, print them now.
                             //
-                            logWriter.WriteConsoleLog(fileName + currentLineBuffer);
+                            LogFileMonitor::WriteToConsole(currentLineBuffer, LogFileInfo->FileName);
 
                             std::wstring remainingBuffer = decodedString.substr(0, found);
-                            logWriter.WriteConsoleLog(fileName + remainingBuffer);
+                            LogFileMonitor::WriteToConsole(remainingBuffer, LogFileInfo->FileName);
                         }
 
                         currentLineBuffer.clear();
@@ -1635,7 +1636,7 @@ LogFileMonitor::ReadLogFile(
                         // newLineBuffer was empty, so only print the found line.
                         //
                         std::wstring foundLineBuffer = decodedString.substr(0, found);
-                        logWriter.WriteConsoleLog(fileName + Utility::ReplaceAll(foundLineBuffer, L"\n", L"\n" + fileName));
+                        LogFileMonitor::WriteToConsole(foundLineBuffer, LogFileInfo->FileName);
                     }
                 }
                 //
@@ -1657,8 +1658,8 @@ LogFileMonitor::ReadLogFile(
                         //
                         std::wstring remainingBuffer(decodedString.begin() + remainingStringIndex, decodedString.end());
 
-                        logWriter.WriteConsoleLog(fileName + currentLineBuffer);
-                        logWriter.WriteConsoleLog(fileName + remainingBuffer);
+                        LogFileMonitor::WriteToConsole(currentLineBuffer, LogFileInfo->FileName);
+                        LogFileMonitor::WriteToConsole(remainingBuffer, LogFileInfo->FileName);
                         currentLineBuffer.clear();
                     }
                 }
@@ -1674,7 +1675,7 @@ LogFileMonitor::ReadLogFile(
         //
         // If we reach EOF, print the last line.
         //
-        logWriter.WriteConsoleLog(fileName + currentLineBuffer);
+        LogFileMonitor::WriteToConsole(currentLineBuffer, LogFileInfo->FileName);
     }
 
     CloseHandle(logFile);
@@ -1682,6 +1683,15 @@ LogFileMonitor::ReadLogFile(
     return status;
 }
 
+void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstring FileName) {
+    wstring prefix;
+    if (m_includeFileNames)
+    {
+        prefix = Utility::FormatString(L"[Log File: %s] ", FileName.c_str());
+    }
+
+    logWriter.WriteConsoleLog(prefix + Utility::ReplaceAll(Message, L"\n", L"\n" + prefix));
+}
 
 DWORD
 LogFileMonitor::GetFilesInDirectory(

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.h
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.h
@@ -195,6 +195,11 @@ private:
         _Inout_ std::shared_ptr<LogFileInformation> LogFileInfo
         );
 
+    void WriteToConsole(
+        _In_ std::wstring Message,
+        _In_ std::wstring FileName
+    );
+
     LM_FILETYPE FileTypeFromBuffer(
         _In_reads_bytes_(ContentSize) LPBYTE FileContents,
         _In_ UINT ContentSize,

--- a/LogMonitor/src/LogMonitor/pch.h
+++ b/LogMonitor/src/LogMonitor/pch.h
@@ -14,7 +14,6 @@
 #include <stdio.h>
 #include <array>
 #include <memory>
-#include <variant>
 #include <cstdint>
 #include <string>
 #include <algorithm>

--- a/LogMonitor/src/LogMonitor/pch.h
+++ b/LogMonitor/src/LogMonitor/pch.h
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <array>
 #include <memory>
+#include <variant>
 #include <cstdint>
 #include <string>
 #include <algorithm>


### PR DESCRIPTION
- This fixes a bug where some new lines were missing the file name prefix when includeFileNames is enabled. It replaces every new line character with newline + file name prefix.