### PR TITLE
wip: eventlog in json

### DIFF
--- a/LogMonitor/LogMonitorTests/EventMonitorTests.cpp
+++ b/LogMonitor/LogMonitorTests/EventMonitorTests.cpp
@@ -122,7 +122,7 @@ namespace LogMonitorTests
                 std::wstring output;
                 int count = 0;
                 
-                std::wregex rgxMessage(Utility::FormatString(L"<Message>%s<\\/Message>", message.c_str()));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Message\": \"%s\"", message.c_str()));
 
                 do
                 {
@@ -136,12 +136,12 @@ namespace LogMonitorTests
                 Assert::IsTrue(std::regex_search(output, rgxMessage),
                                Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxId(Utility::FormatString(L"<EventId>%d<\\/EventId>", eventId));
+                std::wregex rgxId(Utility::FormatString(L"\"EventId\": %d", eventId));
 
                 Assert::IsTrue(std::regex_search(output, rgxId),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxLevel(Utility::FormatString(L"<Level>%s<\\/Level>", c_LevelToString[(int)level]));
+                std::wregex rgxLevel(Utility::FormatString(L"\"Level\": \"%s\"", c_LevelToString[(int)level]));
 
                 Assert::IsTrue(std::regex_search(output, rgxLevel),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -168,7 +168,7 @@ namespace LogMonitorTests
                 //
                 // Monitor should have ignored this event.
                 //
-                std::wregex rgxMessage(Utility::FormatString(L"<Message>%s<\\/Message>", message.c_str()));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Message\": \"%s\"", message.c_str()));
 
                 Assert::IsFalse(std::regex_search(output, rgxMessage),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -195,7 +195,7 @@ namespace LogMonitorTests
                 //
                 // Monitor should have ignored this event.
                 //
-                std::wregex rgxMessage(Utility::FormatString(L"<Message>%s<\\/Message>", message.c_str()));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Message\": \"%s\"", message.c_str()));
 
                 Assert::IsFalse(std::regex_search(output, rgxMessage),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -228,7 +228,7 @@ namespace LogMonitorTests
                 std::wstring output;
                 int count = 0;
                 
-                std::wregex rgxMessage(Utility::FormatString(L"<Message>%s<\\/Message>", message.c_str()));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Message\": \"%s\"", message.c_str()));
 
                 do
                 {
@@ -239,12 +239,12 @@ namespace LogMonitorTests
                 Assert::IsTrue(std::regex_search(output, rgxMessage),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxId(Utility::FormatString(L"<EventId>%d<\\/EventId>", eventId));
+                std::wregex rgxId(Utility::FormatString(L"\"EventId\": %d", eventId));
 
                 Assert::IsTrue(std::regex_search(output, rgxId),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxLevel(Utility::FormatString(L"<Level>%s<\\/Level>", c_LevelToString[(int)level]));
+                std::wregex rgxLevel(Utility::FormatString(L"\"Level\": \"%s\"", c_LevelToString[(int)level]));
 
                 Assert::IsTrue(std::regex_search(output, rgxLevel),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -270,7 +270,7 @@ namespace LogMonitorTests
                 // Test that the created event is printed. We could receive other events,
                 // so is better to loop until our message has arrived, using a regex.
                 //
-                std::wregex rgxMessage(Utility::FormatString(L"<Message>%s<\\/Message>", message.c_str()));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Message\": \"%s\"", message.c_str()));
 
                 do
                 {
@@ -281,12 +281,12 @@ namespace LogMonitorTests
                 Assert::IsTrue(std::regex_search(output, rgxMessage),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxId(Utility::FormatString(L"<EventId>%d<\\/EventId>", eventId));
+                std::wregex rgxId(Utility::FormatString(L"\"EventId\": %d", eventId));
 
                 Assert::IsTrue(std::regex_search(output, rgxId),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxLevel(Utility::FormatString(L"<Level>%s<\\/Level>", c_LevelToString[(int)level]));
+                std::wregex rgxLevel(Utility::FormatString(L"\"Level\": \"%s\"", c_LevelToString[(int)level]));
 
                 Assert::IsTrue(std::regex_search(output, rgxLevel),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -312,7 +312,7 @@ namespace LogMonitorTests
                 // Test that the created event is printed. We could receive other events,
                 // so is better to loop until our message has arrived, using a regex.
                 //
-                std::wregex rgxMessage(Utility::FormatString(L"<Message>%s<\\/Message>", message.c_str()));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Message\": \"%s\"", message.c_str()));
 
                 do
                 {
@@ -323,12 +323,12 @@ namespace LogMonitorTests
                 Assert::IsTrue(std::regex_search(output, rgxMessage),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxId(Utility::FormatString(L"<EventId>%d<\\/EventId>", eventId));
+                std::wregex rgxId(Utility::FormatString(L"\"EventId\": %d", eventId));
 
                 Assert::IsTrue(std::regex_search(output, rgxId),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxLevel(Utility::FormatString(L"<Level>%s<\\/Level>", c_LevelToString[(int)level]));
+                std::wregex rgxLevel(Utility::FormatString(L"\"Level\": \"%s\"", c_LevelToString[(int)level]));
 
                 Assert::IsTrue(std::regex_search(output, rgxLevel),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -368,7 +368,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && READ_OUTPUT_RETRIES > ++count);
 
-                std::wregex rgxMessage(Utility::FormatString(L"<Channel>Application<\\/Channel>"));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Channel\": \"Application\""));
 
                 Assert::IsTrue(std::regex_search(output, rgxMessage),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -398,7 +398,7 @@ namespace LogMonitorTests
                 Sleep(WAIT_TIME_EVENTMONITOR_AFTER_WRITE_LONG);
                 std::wstring output = RecoverOuput();
 
-                std::wregex rgxMessage(Utility::FormatString(L"<Channel>Application<\\/Channel>"));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Channel\": \"Application\""));
 
                 //
                 // We can not ensure that a System event isn't received right
@@ -448,7 +448,7 @@ namespace LogMonitorTests
                 // Test that the created event is printed. We could receive other events,
                 // so is better to loop until our message has arrived, using a regex.
                 //
-                std::wregex rgxMessage(Utility::FormatString(L"<Message>%s<\\/Message>", messageWithoutNewline.c_str()));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Message\": \"%s\"", messageWithoutNewline.c_str()));
 
                 do
                 {

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -552,8 +552,11 @@ EventMonitor::PrintEvent(
 
             if (status == ERROR_SUCCESS)
             {
+                // supporting JSON fmt by default
+                auto logFmt = L"{\"Source\": \"EventLog\",\"LogEntry\": {\"Time\": \"%s\",\"Channel\": \"%s\",\"Level\": \"%s\",\"EventId\": %u,\"Message\": \"%s\"}}";;
+
                 std::wstring formattedEvent = Utility::FormatString(
-                    L"<Source>EventLog</Source><Time>%s</Time><LogEntry><Channel>%s</Channel><Level>%s</Level><EventId>%u</EventId><Message>%s</Message></LogEntry>",
+                    logFmt,
                     Utility::FileTimeToString(fileTimeCreated).c_str(),
                     channelName.c_str(),
                     c_LevelToString[static_cast<UINT8>(level)].c_str(),

--- a/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
+++ b/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
This is a POC PR to get some early feedback even as the discussions continue here -https://github.com/microsoft/windows-container-tools/discussions/103

---

This is the `LogMonitorConfig.json` file I used for testing only EventLogs:
```json
{
  "LogConfig": {
    "sources": [
      {
        "type": "EventLog",
        "startAtOldestRecord": true,
        "eventFormatMultiLine": false,
        "channels": [
          {
            "name": "System",
            "level": "Error"
          }
        ]
       }
    ]
  }
}
```