### PR TITLE
include provider name to xml output log for ETW monitoring 

### DIFF
--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -794,6 +794,7 @@ EtwMonitor::FormatMetadata(
 {
     std::wostringstream oss;
     FILETIME fileTime;
+    LPWSTR pName = NULL;
 
     //
     // Format the time of the event
@@ -802,6 +803,14 @@ EtwMonitor::FormatMetadata(
     fileTime.dwLowDateTime = EventRecord->EventHeader.TimeStamp.LowPart;
 
     oss << L"<Time>" << Utility::FileTimeToString(fileTime).c_str() << L"</Time>";
+
+    //
+    // Format provider Name
+    //
+    if (EventInfo->ProviderNameOffset > 0) {
+        pName = (LPWSTR)((PBYTE)(EventInfo)+EventInfo->ProviderNameOffset);
+    }
+    oss << L"<Provider Name=\"" << pName << "\"/>";
 
     //
     // Format provider Id
@@ -868,6 +877,8 @@ EtwMonitor::FormatMetadata(
     //
     if (DecodingSourceWbem == EventInfo->DecodingSource)  // MOF class
     {
+        oss << L"<Provider Name=\"" << pName << "\"/>";
+
         LPWSTR pwsEventGuid = NULL;
         hr = StringFromCLSID(EventInfo->EventGuid, &pwsEventGuid);
 


### PR DESCRIPTION
Output logs appearance. Note **Provide Name** is part of the output 

`	<Source>EtwEvent</Source>
	<Time>2022-12-17T18:14:45.000Z</Time>
	<Provider Name="Microsoft-Windows-WLAN-Driver"/>
	<Provider idGuid="{DAA6A96B-F3E7-4D4D-A0D6-31A350E6A445}"/>
	<DecodingSource>DecodingSourceXMLFile</DecodingSource>
	<Execution ProcessID="0" ThreadID="0" />
	<Level>Information</Level>
	<Keyword>0x8000000000000001</Keyword>
	<EventID Qualifiers="0">0</EventID>
	<EventData>
		<FrameUniqueID>9425125</FrameUniqueID>
		<PortNumber>0</PortNumber>
		<TID>0</TID>
		<PeerID>0</PeerID>
		<PayloadLength>49</PayloadLength>
		<QueueLength>0</QueueLength>
		<QueueState>false</QueueState>
		<CustomData1>24</CustomData1>
		<CustomData2>0</CustomData2>
		<CustomData3>0</CustomData3>
	`</EventData>``

Sample JSON configuration to used to test this change:
`{
  "LogConfig": {
    "sources": [
      {
        "type": "ETW",
        "eventFormatMultiLine": false,
        "providers": [
          {
            "providerName": "Microsoft-Windows-WLAN-Driver",
            "providerGuid": "DAA6A96B-F3E7-4D4D-A0D6-31A350E6A445",
            "level": "Information"
          }
        ]
      }
    ]
  }
}`