### PR TITLE
added standard XML preamble and enclosing tag for each ETW event log

### DIFF
--- a/LogMonitor/LogMonitorTests/EtwMonitorTests.cpp
+++ b/LogMonitor/LogMonitorTests/EtwMonitorTests.cpp
@@ -74,7 +74,7 @@ namespace LogMonitorTests
                 ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
                 fflush(stdout);
 
-                EtwMonitor etwMonitor(etwProviders, true);
+                EtwMonitor etwMonitor(etwProviders, true, false);
                 Sleep(WAIT_TIME_ETWMONITOR_START);
 
                 
@@ -152,7 +152,7 @@ namespace LogMonitorTests
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
             fflush(stdout);
 
-            EtwMonitor etwMonitor(etwProviders, true);
+            EtwMonitor etwMonitor(etwProviders, true, false);
 
             //
             // It must find the provider, and start printing events.
@@ -187,7 +187,7 @@ namespace LogMonitorTests
             fflush(stdout);
 
 
-            std::function<void(void)> f1 = [&etwProviders] { EtwMonitor etwMonitor(etwProviders, true); };
+            std::function<void(void)> f1 = [&etwProviders] { EtwMonitor etwMonitor(etwProviders, true, false); };
             Assert::ExpectException<std::invalid_argument>(f1);
         }
     };

--- a/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
+++ b/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
@@ -334,7 +334,12 @@ ReadSourceAttributes(
                 || _wcsnicmp(
                     key.c_str(),
                     JSON_TAG_INCLUDE_FILENAMES,
-                    _countof(JSON_TAG_INCLUDE_FILENAMES)) == 0)
+                    _countof(JSON_TAG_INCLUDE_FILENAMES)) == 0
+                || _wcsnicmp(
+                    key.c_str(),
+                    JSON_TAG_INCLUDE_PREAMBLE_TAG,
+                    _countof(JSON_TAG_INCLUDE_PREAMBLE_TAG)) == 0
+                    )
             {
                 Attributes[key] = new bool{ Parser.ParseBooleanValue() };
             }
@@ -672,6 +677,7 @@ void _PrintSettings(_Out_ LoggerSettings& Config)
             std::shared_ptr<SourceETW> sourceETW = std::reinterpret_pointer_cast<SourceETW>(source);
 
             std::wprintf(L"\t\teventFormatMultiLine: %ls\n", sourceETW->EventFormatMultiLine ? L"true" : L"false");
+            std::wprintf(L"\t\tincludePreambleTag: %ls\n", sourceETW->PreambleTag ? L"true" : L"false");
 
             std::wprintf(L"\t\tProviders (%d):\n", (int)sourceETW->Providers.size());
             for (auto provider : sourceETW->Providers)

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -39,6 +39,12 @@ EtwMonitor::EtwMonitor(
     //
     m_stopFlag = false;
 
+    logWriter.WriteConsoleLog(
+        Utility::FormatString(
+            L"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        )
+    );
+
     FilterValidProviders(Providers, m_providersConfig);
 
     if (m_providersConfig.empty())
@@ -748,7 +754,7 @@ EtwMonitor::PrintEvent(
         }
 
         std::wstring formattedEvent = Utility::FormatString(
-            L"<Source>EtwEvent</Source>%ls%ls",
+            L"<EventLog><Source>EtwEvent</Source>%ls%ls</EventLog>",
             metadataStr.c_str(),
             dataStr.c_str());
 

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -30,20 +30,25 @@ static const std::wstring g_sessionName = L"Log Monitor ETW Session";
 
 EtwMonitor::EtwMonitor(
     _In_ const std::vector<ETWProvider>& Providers,
-    _In_ bool EventFormatMultiLine
+    _In_ bool EventFormatMultiLine,
+    _In_ bool PreambleTag
     ) :
-    m_eventFormatMultiLine(EventFormatMultiLine)
+    m_eventFormatMultiLine(EventFormatMultiLine),
+    m_preambleTag(PreambleTag)
 {
     //
     // This is set as 'true' to stop processing events.
     //
     m_stopFlag = false;
 
-    logWriter.WriteConsoleLog(
+    if(m_preambleTag)
+    {
+        logWriter.WriteConsoleLog(
         Utility::FormatString(
             L"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
-        )
-    );
+            )
+        );
+    }
 
     FilterValidProviders(Providers, m_providersConfig);
 

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -754,7 +754,7 @@ EtwMonitor::PrintEvent(
         }
 
         std::wstring formattedEvent = Utility::FormatString(
-            L"<EventLog><Source>EtwEvent</Source>%ls%ls</EventLog>",
+            L"<Event xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\"><Source>EtwEvent</Source>%ls%ls</Event>",
             metadataStr.c_str(),
             dataStr.c_str());
 

--- a/LogMonitor/src/LogMonitor/EtwMonitor.h
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.h
@@ -17,7 +17,8 @@ public:
 
     EtwMonitor(
         _In_ const std::vector<ETWProvider>& Providers,
-        _In_ bool EventFormatMultiLine
+        _In_ bool EventFormatMultiLine,
+        _In_ bool PreambleTag
     );
 
     ~EtwMonitor();
@@ -27,6 +28,7 @@ private:
 
     std::vector<ETWProvider> m_providersConfig;
     bool m_eventFormatMultiLine;
+    bool m_preambleTag;
     TRACEHANDLE m_startTraceHandle;
 
     //

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -84,6 +84,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
     bool eventMonMultiLine;
     bool eventMonStartAtOldestRecord;
     bool etwMonMultiLine;
+    bool etwPreambleTag;
 
     for (auto source : settings.Sources)
     {
@@ -150,6 +151,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
                 }
 
                 etwMonMultiLine = sourceETW->EventFormatMultiLine;
+                etwPreambleTag = sourceETW->PreambleTag;
 
                 break;
             }
@@ -185,7 +187,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
     {
         try
         {
-            g_etwMon = make_unique<EtwMonitor>(etwProviders, etwMonMultiLine);
+            g_etwMon = make_unique<EtwMonitor>(etwProviders, etwMonMultiLine, etwPreambleTag);
         }
         catch (...)
         {

--- a/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
+++ b/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
@@ -22,6 +22,7 @@
 #define JSON_TAG_INCLUDE_SUBDIRECTORIES L"includeSubdirectories"
 #define JSON_TAG_INCLUDE_FILENAMES L"includeFileNames"
 #define JSON_TAG_PROVIDERS L"providers"
+#define JSON_TAG_INCLUDE_PREAMBLE_TAG L"includePreambleTag"
 
 ///
 /// Valid channel attributes
@@ -370,6 +371,7 @@ class SourceETW : LogSource
 public:
     std::vector<ETWProvider> Providers;
     bool EventFormatMultiLine = true;
+    bool PreambleTag = false;
 
     static bool Unwrap(
         _In_ AttributesMap& Attributes,
@@ -398,6 +400,15 @@ public:
             && Attributes[JSON_TAG_FORMAT_MULTILINE] != nullptr)
         {
             NewSource.EventFormatMultiLine = *(bool*)Attributes[JSON_TAG_FORMAT_MULTILINE];
+        }
+
+        //
+        // preambleTag is an optional value
+        //
+        if (Attributes.find(JSON_TAG_INCLUDE_PREAMBLE_TAG) != Attributes.end()
+            && Attributes[JSON_TAG_INCLUDE_PREAMBLE_TAG] != nullptr)
+        {
+            NewSource.PreambleTag = *(bool*)Attributes[JSON_TAG_INCLUDE_PREAMBLE_TAG];
         }
 
 


### PR DESCRIPTION
This is how the sample XML output looks with this change:

`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<EventLog>
	<Source>EtwEvent</Source>
	<Time>2022-12-18T03:03:02.000Z</Time>
	<Provider idGuid="{DAA6A96B-F3E7-4D4D-A0D6-31A350E6A445}"/>
	<DecodingSource>DecodingSourceXMLFile</DecodingSource>
	<Execution ProcessID="11148" ThreadID="4064" />
	<Level>Information</Level>
	<Keyword>0x8000000000000001</Keyword>
	<EventID Qualifiers="0">0</EventID>
	<EventData>
		<FrameUniqueID>228261</FrameUniqueID>
		<PortNumber>0</PortNumber>
		<TID>0</TID>
		<PeerID>0</PeerID>
		<PayloadLength>122</PayloadLength>
		<QueueLength>0</QueueLength>
		<QueueState>false</QueueState>
		<CustomData1>24</CustomData1>
		<CustomData2>0</CustomData2>
		<CustomData3>0</CustomData3>
	</EventData>
</EventLog>`

Note the addition of `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` at the top of the file and **EventLog** starting and closing tag.


Sample config file to test the change:

`{
  "LogConfig": {
    "sources": [
      {
        "type": "ETW",
        "eventFormatMultiLine": false,
        "providers": [
          {
            "providerName": "Microsoft-Windows-WLAN-Driver",
            "providerGuid": "DAA6A96B-F3E7-4D4D-A0D6-31A350E6A445",
            "level": "Information"
          }
        ]
      }
    ]
  }
}`