### PR TITLE
Configurable Logging

### DIFF
--- a/LogMonitor/LogMonitorTests/LogMonitorTests.vcxproj
+++ b/LogMonitor/LogMonitorTests/LogMonitorTests.vcxproj
@@ -91,6 +91,9 @@
     <IncludePath>$(IncludePath)</IncludePath>
     <SourcePath>$(SourcePath)</SourcePath>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <VcpkgTriplet>x64-windows-static</VcpkgTriplet>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/LogMonitor/LogMonitorTests/pch.h
+++ b/LogMonitor/LogMonitorTests/pch.h
@@ -12,6 +12,8 @@
 #ifndef PCH_H
 #define PCH_H
 
+#define BOOST_USE_WINAPI_VERSION BOOST_WINAPI_VERSION_WIN7
+
 // add headers that you want to pre-compile here
 
 #include "CppUnitTest.h"

--- a/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
+++ b/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
@@ -139,9 +139,10 @@ ReadLogConfigObject(
     bool sourcesTagFound = false;
     if (Parser.BeginParseObject())
     {
+        std::wstring key;
         do
         {
-            const std::wstring key(Parser.GetKey());
+            key = Parser.GetKey();
 
             if (_wcsnicmp(key.c_str(), JSON_TAG_SOURCES, _countof(JSON_TAG_SOURCES)) == 0)
             {
@@ -186,6 +187,10 @@ ReadLogConfigObject(
                         }
                     }
                 } while (Parser.ParseNextArrayElement());
+            }
+            else if (_wcsnicmp(key.c_str(), JSON_TAG_LOG_FORMAT, _countof(JSON_TAG_LOG_FORMAT)) == 0)
+            {
+                Config.LogFormat = std::wstring(Parser.ParseStringValue());
             }
             else
             {

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -768,6 +768,9 @@ EtwMonitor::PrintEvent(
                 });
         }
 
+        //add custom attributes
+        boost::log::core::get()->add_global_attribute("Source", boost::log::attributes::constant<string>("ETW"));
+
         logWriter.WriteConsoleLog(formattedEvent);
     }
     catch(std::bad_alloc&)

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -577,6 +577,9 @@ EventMonitor::PrintEvent(
                         });
                 }
 
+                //add custom attributes
+                boost::log::core::get()->add_global_attribute("Source", boost::log::attributes::constant<string>("EventLog"));
+
                 logWriter.WriteConsoleLog(formattedEvent);
             }
         }

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1435,6 +1435,9 @@ LogFileMonitor::ReadLogFile(
         );
     }
 
+    //add custom attributes
+    boost::log::core::get()->add_global_attribute("Source", boost::log::attributes::constant<string>("File"));
+
     //
     // If the beginning of the file hasn't been read yet, don't get the BOM.
     // Also, if EncodingType is already known, skip this.

--- a/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
+++ b/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
+++ b/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
@@ -82,6 +82,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <VcpkgTriplet>x64-windows-static</VcpkgTriplet>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/LogMonitor/src/LogMonitor/LogWriter.h
+++ b/LogMonitor/src/LogMonitor/LogWriter.h
@@ -3,6 +3,8 @@
 // Licensed under the MIT license.
 //
 
+#include "pch.h"
+
 #pragma once
 
 class LogWriter final
@@ -64,10 +66,9 @@ public :
     {
         AcquireSRWLockExclusive(&m_stdoutLock);
 
-        wprintf(L"%s\n", LogMessage.c_str());
-        FlushStdOut();
+        BOOST_LOG_TRIVIAL(info) << LogMessage.data();
 
-        ReleaseSRWLockExclusive(&m_stdoutLock);
+        clear();
     }
 
     void WriteConsoleLog(
@@ -76,52 +77,54 @@ public :
     {
         AcquireSRWLockExclusive(&m_stdoutLock);
 
-        wprintf(L"%s\n", LogMessage.c_str());
-        FlushStdOut();
+        BOOST_LOG_TRIVIAL(info) << LogMessage.data();
 
-        ReleaseSRWLockExclusive(&m_stdoutLock);
+        clear();
     }
 
     void TraceError(
         _In_ LPCWSTR Message
     )
     {
-        SYSTEMTIME st;
-        GetSystemTime(&st);
+        AcquireSRWLockExclusive(&m_stdoutLock);
 
-        std::wstring formattedMessage = Utility::FormatString(L"[%s][LOGMONITOR] ERROR: %s",
-            Utility::SystemTimeToString(st).c_str(),
-            Message);
+        const std::wstring& LogMessage = Message;
 
-        WriteConsoleLog(formattedMessage);
+        BOOST_LOG_TRIVIAL(error) << LogMessage.data();
+
+        clear();
     }
 
     void TraceWarning(
         _In_ LPCWSTR Message
     )
     {
-        SYSTEMTIME st;
-        GetSystemTime(&st);
+        AcquireSRWLockExclusive(&m_stdoutLock);
 
-        std::wstring formattedMessage = Utility::FormatString(L"[%s][LOGMONITOR] WARNING: %s",
-            Utility::SystemTimeToString(st).c_str(),
-            Message);
+        const std::wstring& LogMessage = Message;
 
-        WriteConsoleLog(formattedMessage);
+        BOOST_LOG_TRIVIAL(error) << LogMessage.data();
+
+        clear();
     }
 
     void TraceInfo(
         _In_ LPCWSTR Message
     )
     {
-        SYSTEMTIME st;
-        GetSystemTime(&st);
+        AcquireSRWLockExclusive(&m_stdoutLock);
 
-        std::wstring formattedMessage = Utility::FormatString(L"[%s][LOGMONITOR] INFO: %s",
-            Utility::SystemTimeToString(st).c_str(),
-            Message);
+        const std::wstring& LogMessage = Message;
 
-        WriteConsoleLog(formattedMessage);
+        BOOST_LOG_TRIVIAL(error) << LogMessage.data();
+
+        clear();
+    }
+
+    void clear() {
+        FlushStdOut();
+
+        ReleaseSRWLockExclusive(&m_stdoutLock);
     }
 };
 

--- a/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
+++ b/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
@@ -9,6 +9,7 @@
 
 #define JSON_TAG_LOG_CONFIG L"LogConfig"
 #define JSON_TAG_SOURCES L"sources"
+#define JSON_TAG_LOG_FORMAT L"logFormat"
 
 ///
 /// Valid source attributes
@@ -411,4 +412,5 @@ public:
 typedef struct _LoggerSettings
 {
     std::vector<std::shared_ptr<LogSource> > Sources;
+    std::wstring LogFormat;
 } LoggerSettings;

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -245,3 +245,18 @@ std::wstring Utility::ReplaceAll(_In_ std::wstring Str, _In_ const std::wstring&
     return Str;
 }
 
+/// <summary>
+/// Convert wstring to string
+/// </summary>
+/// <param name="wstr">wstring to be converted to string</param>
+std::string Utility::WStringToStringConversion(_In_ const std::wstring& wstr)
+{
+    std::string str;
+    std::size_t size;
+    str.resize(wstr.length());
+
+    wcstombs_s(&size, &str[0], str.size() + 1, wstr.c_str(), wstr.size());
+
+    return str;
+}
+

--- a/LogMonitor/src/LogMonitor/Utility.h
+++ b/LogMonitor/src/LogMonitor/Utility.h
@@ -44,4 +44,8 @@ public:
         _In_ const std::wstring& From,
         _In_ const std::wstring& To
     );
+
+    static std::string WStringToStringConversion(
+        _In_ const std::wstring& wstr
+    );
 };

--- a/LogMonitor/src/LogMonitor/pch.h
+++ b/LogMonitor/src/LogMonitor/pch.h
@@ -5,6 +5,8 @@
 #ifndef PCH_H
 #define PCH_H
 
+#define BOOST_USE_WINAPI_VERSION BOOST_WINAPI_VERSION_WIN7
+
 // TODO(annandaa): reorder the header files as per convention.
 // currently there are some implicit dependencies, things break when
 // you try to reorder.

--- a/LogMonitor/src/LogMonitor/pch.h
+++ b/LogMonitor/src/LogMonitor/pch.h
@@ -45,6 +45,11 @@
 #include "shlwapi.h"
 #include <io.h> 
 #include <fcntl.h>
+#include <boost/log/core.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/log/expressions.hpp>
+#include <boost/log/utility/setup/console.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
 #include "Utility.h"
 #include "Parser/ConfigFileParser.h"
 #include "Parser/LoggerSettings.h"

--- a/LogMonitor/src/LogMonitor/sample-config-files/IIS/LogMonitorConfig.json
+++ b/LogMonitor/src/LogMonitor/sample-config-files/IIS/LogMonitorConfig.json
@@ -39,6 +39,7 @@
           }
         ]
       }
-    ]
+    ],
+	"logFormat": "[%TimeStamp%] [%Severity%] %Message%"
   }
 }


### PR DESCRIPTION
Prerequisite to testing the change locally: `.\vcpkg install boost:x64-windows-static`


### Examples
**Configuration:**
![image](https://user-images.githubusercontent.com/28774968/214011261-c01cbdc1-4244-40dd-8c72-b9cdf5e69683.png)

**Output:**
![image](https://user-images.githubusercontent.com/28774968/214011127-60f30480-4312-449d-9c51-8608b4880935.png)
