### PR TITLE
feat: refactor ETWMonitor code to easily support multiple output formats

### DIFF
--- a/LogMonitor/LogMonitorTests/UtilityTests.cpp
+++ b/LogMonitor/LogMonitorTests/UtilityTests.cpp
@@ -20,7 +20,7 @@ namespace UtilityTests
     public:
         TEST_METHOD(TestisJsonNumberTrue)
         {
-            PWSTR str = L"-0.12";
+            std::wstring str = L"-0.12";
             Assert::IsTrue(Utility::isJsonNumber(str), L"should return true -0.12");
 
             str = L"-1.1234";
@@ -44,7 +44,7 @@ namespace UtilityTests
 
         TEST_METHOD(TestisJsonNumberFalse)
         {
-            PWSTR str = L"false";
+            std::wstring str = L"false";
             Assert::IsFalse(Utility::isJsonNumber(str), L"should return false for \"false\"");
 
             str = L"12.12.89.12";

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -705,6 +705,69 @@ EtwMonitor::OnRecordEvent(
     return status;
 }
 
+///
+/// Format ETW eventlog into a JSON output
+///
+std::wstring etwJsonFormat(EtwLogEntry* pLogEntry)
+{
+    std::wostringstream oss;
+    // construct the JSON output
+    oss << L"{\"Source\":\"ETW\",\"LogEntry\":{";
+    oss << L"\"Time\":\"" << pLogEntry->Time << L"\",";
+    oss << L"\"ProviderName\":\"" << pLogEntry->ProviderName << L"\",";
+    oss << L"\"ProviderId\":\"" << pLogEntry->ProviderId << "\",";
+    oss << L"\"DecodingSource\":\"" << pLogEntry->DecodingSource << L"\",";
+    oss << L"\"Execution\":{";
+    oss << L"\"ProcessId\":" << pLogEntry->ExecProcessId << ",";
+    oss << L"\"ThreadId\":" << pLogEntry->ExecThreadId;
+    oss << "},";
+    oss << L"\"Level\":\"" << pLogEntry->Level << L"\",";
+    oss << L"\"Keyword\":\"" << pLogEntry->Keyword << L"\",";
+    oss << L"\"EventId\":\"" << pLogEntry->EventId << "\",";
+
+    oss << L"\"EventData\":{";
+    bool firstEntry = true;
+    for (auto evtData : pLogEntry->EventData) {
+        oss << (firstEntry ? "" : ",");
+        firstEntry = false;
+
+        wstring key = evtData.first;
+        Utility::SanitizeJson(key);
+        oss << "\"" << key << "\":";
+
+        //
+        // format (JSON) numbers without quotation marks, e.g.
+        /*
+        "EventData": {
+                "FrameUniqueID": 403787,
+                "PortNumber" : 0,
+                "TID" : 0,
+                "PeerID" : 0,
+                "PayloadLength" : 68,
+                "QueueLength" : 0,
+                "QueueState" : "false",
+                "CustomData1" : 24,
+                "CustomData2" : 0,
+                "CustomData3" : 0
+        }
+        */
+        //
+        if (Utility::isJsonNumber(evtData.second)) {
+            oss << evtData.second;
+        }
+        else {
+            wstring value = evtData.second;
+            Utility::SanitizeJson(value);
+            oss << L"\"" << value << L"\"";
+        }
+    }
+    oss << L"}";
+
+    oss << L"},\"SchemaVersion\":\"1.0.0\"}";
+
+    return oss.str();
+}
+
 
 ///
 /// Prints the data and metadata of the event.
@@ -722,11 +785,14 @@ EtwMonitor::PrintEvent(
     )
 {
     DWORD status = ERROR_SUCCESS;
+    
+    // struct to hold the Etw log entry and later format print
+    EtwLogEntry logEntry;
+    EtwLogEntry* pLogEntry = &logEntry;
 
     try
     {
-        std::wstring metadataStr;
-        status = FormatMetadata(EventRecord, EventInfo, metadataStr);
+        status = FormatMetadata(EventRecord, EventInfo, pLogEntry);
 
         if (status != ERROR_SUCCESS)
         {
@@ -737,7 +803,7 @@ EtwMonitor::PrintEvent(
         }
 
         std::wstring dataStr;
-        status = FormatData(EventRecord, EventInfo, dataStr);
+        status = FormatData(EventRecord, EventInfo, pLogEntry);
 
         if (status != ERROR_SUCCESS)
         {
@@ -747,27 +813,7 @@ EtwMonitor::PrintEvent(
             return status;
         }
 
-        std::wstring formattedEvent = Utility::FormatString(
-            L"{\"Source\":\"ETW\",\"LogEntry\":{%ls%ls},\"SchemaVersion\":\"1.0.0\"}",
-            metadataStr.c_str(),
-            dataStr.c_str());
-
-        //
-        // If the multi-line option is disabled, remove all new lines from the output.
-        //
-        if (!this->m_eventFormatMultiLine)
-        {
-            std::transform(formattedEvent.begin(), formattedEvent.end(), formattedEvent.begin(),
-                [](WCHAR ch) {
-                    switch (ch) {
-                    case L'\r':
-                    case L'\n':
-                        return L' ';
-                    }
-                    return ch;
-                });
-        }
-
+        std::wstring formattedEvent = etwJsonFormat(pLogEntry);
         logWriter.WriteConsoleLog(formattedEvent);
     }
     catch(std::bad_alloc&)
@@ -789,10 +835,9 @@ DWORD
 EtwMonitor::FormatMetadata(
     _In_ const PEVENT_RECORD EventRecord,
     _In_ const PTRACE_EVENT_INFO EventInfo,
-    _Inout_ std::wstring& Result
+    _Inout_ EtwLogEntry* pLogEntry
     )
 {
-    std::wostringstream oss;
     FILETIME fileTime;
     LPWSTR pName = NULL;
 
@@ -802,7 +847,7 @@ EtwMonitor::FormatMetadata(
     fileTime.dwHighDateTime = EventRecord->EventHeader.TimeStamp.HighPart;
     fileTime.dwLowDateTime = EventRecord->EventHeader.TimeStamp.LowPart;
 
-    oss << L"\"Time\":\"" << Utility::FileTimeToString(fileTime).c_str() << L"\",";
+    pLogEntry->Time = Utility::FileTimeToString(fileTime).c_str();
 
     //
     // Format provider Name
@@ -810,7 +855,7 @@ EtwMonitor::FormatMetadata(
     if (EventInfo->ProviderNameOffset > 0) {
         pName = (LPWSTR)((PBYTE)(EventInfo)+EventInfo->ProviderNameOffset);
     }
-    oss << L"\"ProviderName\":\"" << pName << L"\",";
+    pLogEntry->ProviderName = pName;
 
     //
     // Format provider Id
@@ -826,7 +871,7 @@ EtwMonitor::FormatMetadata(
         return hr;
     }
 
-    oss << L"\"ProviderId\":\"" << pwsProviderId << "\",";
+    pLogEntry->ProviderId = std::wstring(pwsProviderId);
     CoTaskMemFree(pwsProviderId);
     pwsProviderId = NULL;
 
@@ -842,13 +887,10 @@ EtwMonitor::FormatMetadata(
         L"DecodingSourceMax",
     };
 
-    oss << L"\"DecodingSource\":\""
-        << c_DecodingSourceToString[static_cast<UINT8>(EventInfo->DecodingSource)].c_str()
-        << L"\",";
+    pLogEntry->DecodingSource = c_DecodingSourceToString[static_cast<UINT8>(EventInfo->DecodingSource)].c_str();
 
-    oss << L"\"Execution\":{\"ProcessId\":"
-        << EventRecord->EventHeader.ProcessId << ",\"ThreadId\":"
-        << EventRecord->EventHeader.ThreadId << "},";
+    pLogEntry->ExecProcessId = EventRecord->EventHeader.ProcessId;
+    pLogEntry->ExecThreadId = EventRecord->EventHeader.ThreadId;
 
     //
     // Print Level and Keyword
@@ -863,14 +905,9 @@ EtwMonitor::FormatMetadata(
         L"Verbose",
     };
 
-    oss << L"\"Level\":\""
-        << c_LevelToString[EventRecord->EventHeader.EventDescriptor.Level]
-        << L"\",";
+    pLogEntry->Level = c_LevelToString[EventRecord->EventHeader.EventDescriptor.Level];
 
-    oss << L"\"Keyword\":\""
-        << Utility::FormatString(L"0x%llx", EventRecord->EventHeader.EventDescriptor.Keyword)
-        << L"\",";
-
+    pLogEntry->Keyword = Utility::FormatString(L"0x%llx", EventRecord->EventHeader.EventDescriptor.Keyword);
 
     //
     // Format specific metadata by type
@@ -889,19 +926,15 @@ EtwMonitor::FormatMetadata(
             return hr;
         }
 
-        oss << L"\"EventId\":\"" << pwsEventGuid << "\",";;
+        std::wstring eventId(pwsEventGuid);
+        pLogEntry->EventId = eventId;
         CoTaskMemFree(pwsEventGuid);
         pwsEventGuid = NULL;
     }
     else if (DecodingSourceXMLFile == EventInfo->DecodingSource) // Instrumentation manifest
     {
-        oss << L"\"EventId\":" << (int)EventInfo->EventDescriptor.Id << ",";
+        pLogEntry->EventId = std::to_wstring(EventInfo->EventDescriptor.Id);
     }
-
-    //
-    // Convert the stream to a wstring
-    //
-    Result = oss.str();
 
     return ERROR_SUCCESS;
 }
@@ -920,7 +953,7 @@ DWORD
 EtwMonitor::FormatData(
     _In_ const PEVENT_RECORD EventRecord,
     _In_ const PTRACE_EVENT_INFO EventInfo,
-    _Inout_ std::wstring& Result
+    _Inout_ EtwLogEntry* pLogEntry
     )
 {
     DWORD status = ERROR_SUCCESS;
@@ -941,10 +974,10 @@ EtwMonitor::FormatData(
     // property information array. If the EVENT_HEADER_FLAG_STRING_ONLY flag is set,
     // the event data is a null-terminated string, so just print it.
     //
-    oss << L"\"EventData\":{";
     if (EVENT_HEADER_FLAG_STRING_ONLY == (EventRecord->EventHeader.Flags & EVENT_HEADER_FLAG_STRING_ONLY))
     {
-        oss << (LPWSTR)EventRecord->UserData;
+        std::wstring data((LPWSTR)EventRecord->UserData);
+        pLogEntry->EventData.push_back(std::make_pair(L"Header", data));
     }
     else
     {
@@ -953,7 +986,7 @@ EtwMonitor::FormatData(
 
         for (USHORT i = 0; i < EventInfo->TopLevelPropertyCount; i++)
         {
-            status = _FormatData(EventRecord, EventInfo, i, pUserData, pEndOfUserData, oss);
+            status = _FormatData(EventRecord, EventInfo, i, pUserData, pEndOfUserData, pLogEntry);
             if (ERROR_SUCCESS != status)
             {
                 logWriter.TraceError(L"Failed to format ETW event user data..");
@@ -962,12 +995,6 @@ EtwMonitor::FormatData(
             }
         }
     }
-    oss << L"}";
-
-    Result = oss.str();
-
-    // tream off the trailing comma (,) for the last key/value pair
-    Result.replace(Result.size() - 2, 1, L"");
 
     return ERROR_SUCCESS;
 }
@@ -993,7 +1020,7 @@ EtwMonitor::_FormatData(
     _In_ USHORT Index,
     _Inout_ PBYTE& UserData,
     _In_ PBYTE EndOfUserData,
-    _Inout_ std::wostringstream& Result
+    _Inout_ EtwLogEntry* pLogEntry
     )
 {
     DWORD status = ERROR_SUCCESS;
@@ -1022,7 +1049,8 @@ EtwMonitor::_FormatData(
 
     for (USHORT k = 0; k < arraySize; k++)
     {
-        Result << "\"" << (LPWSTR)((PBYTE)(EventInfo) + EventInfo->EventPropertyInfoArray[Index].NameOffset) << "\":";
+        std::wstring evtKey((LPWSTR)((PBYTE)(EventInfo) + EventInfo->EventPropertyInfoArray[Index].NameOffset));
+        pLogEntry->EventData.push_back(std::make_pair(evtKey, L""));
 
         //
         // If the property is a structure, print the members of the structure.
@@ -1034,7 +1062,7 @@ EtwMonitor::_FormatData(
 
             for (USHORT j = EventInfo->EventPropertyInfoArray[Index].structType.StructStartIndex; j < lastMember; j++)
             {
-                status = _FormatData(EventRecord, EventInfo, j, UserData, EndOfUserData, Result);
+                status = _FormatData(EventRecord, EventInfo, j, UserData, EndOfUserData, pLogEntry);
                 if (ERROR_SUCCESS != status || UserData == NULL)
                 {
                     logWriter.TraceError(L"Failed to format ETW event user data.");
@@ -1122,16 +1150,9 @@ EtwMonitor::_FormatData(
             if (ERROR_SUCCESS == status)
             {
                 auto fd = (PWCHAR)formattedData.data();
-                if (!Utility::isJsonNumber(fd)) {
-                    // clean the JSON string `fd`
-                    wstring fdStr(fd);
-                    Utility::SanitizeJson(fdStr);
-                    Result << L"\"" << fdStr << L"\"";
-                }
-                else {
-                    Result << fd;
-                }
-                
+                std::wstring evtValue(fd);
+                // the key, evtKey was already set earlier
+                pLogEntry->EventData.back().second = evtValue;
 
                 UserData += userDataConsumed;
             }
@@ -1147,7 +1168,6 @@ EtwMonitor::_FormatData(
                 break;
             }
         }
-        Result << ",";
     }
 
     return status;

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -813,14 +813,6 @@ EtwMonitor::FormatMetadata(
     oss << L"\"ProviderName\":\"" << pName << L"\",";
 
     //
-    // Format provider Name
-    //
-    if (EventInfo->ProviderNameOffset > 0) {
-        pName = (LPWSTR)((PBYTE)(EventInfo)+EventInfo->ProviderNameOffset);
-    }
-    oss << L"<Provider Name=\"" << pName << "\"/>";
-
-    //
     // Format provider Id
     //
     LPWSTR pwsProviderId = NULL;

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -914,8 +914,6 @@ EtwMonitor::FormatMetadata(
     //
     if (DecodingSourceWbem == EventInfo->DecodingSource)  // MOF class
     {
-        oss << L"<Provider Name=\"" << pName << "\"/>";
-
         LPWSTR pwsEventGuid = NULL;
         hr = StringFromCLSID(EventInfo->EventGuid, &pwsEventGuid);
         if (FAILED(hr))

--- a/LogMonitor/src/LogMonitor/EtwMonitor.h
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.h
@@ -10,6 +10,23 @@ typedef LPTSTR(NTAPI* PIPV6ADDRTOSTRING)(
     LPTSTR S
     );
 
+//
+// struct to hold the ETW logEntry data
+//
+struct EtwLogEntry {
+    std::wstring Time;
+    std::wstring ProviderId;
+    std::wstring ProviderName;
+    std::wstring DecodingSource;
+    int ExecProcessId;
+    int ExecThreadId;
+    std::wstring Level;
+    std::wstring Keyword;
+    std::wstring EventId;
+    std::vector<std::pair<std::wstring, std::wstring>> EventData{};
+};
+
+
 class EtwMonitor final
 {
 public:
@@ -86,7 +103,7 @@ private:
     DWORD FormatMetadata(
         _In_ const PEVENT_RECORD EventRecord,
         _In_ const PTRACE_EVENT_INFO EventInfo,
-        _Inout_ std::wstring& Result
+        _Inout_ EtwLogEntry* pLogEntry
     );
 
     //
@@ -95,7 +112,7 @@ private:
     DWORD FormatData(
         _In_ const PEVENT_RECORD EventRecord,
         _In_ const PTRACE_EVENT_INFO EventInfo,
-        _Inout_ std::wstring& Result
+        _Inout_ EtwLogEntry* pLogEntry
     );
 
     DWORD _FormatData(
@@ -104,7 +121,7 @@ private:
         _In_ USHORT Index,
         _Inout_ PBYTE& UserData,
         _In_ PBYTE EndOfUserData,
-        _Inout_ std::wostringstream& Result
+        _Inout_ EtwLogEntry* pLogEntry
     );
 
     DWORD GetPropertyLength(

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -250,8 +250,9 @@ std::wstring Utility::ReplaceAll(_In_ std::wstring Str, _In_ const std::wstring&
 /// 
 /// helper function for a basic check if a string is a Number (JSON)
 /// as per the JSON spec - https://www.json.org/json-en.html
+/// only numbers not covered are those in scientific e-notation
 /// 
-bool Utility::isJsonNumber(_In_ PWSTR str)
+bool Utility::isJsonNumber(_In_ std::wstring& str)
 {
     wregex isNumber(L"(^\\-?\\d+$)|(^\\-?\\d+\\.\\d+)$");
     return regex_search(str, isNumber);

--- a/LogMonitor/src/LogMonitor/Utility.h
+++ b/LogMonitor/src/LogMonitor/Utility.h
@@ -45,7 +45,7 @@ public:
         _In_ const std::wstring& To
     );
 
-    static bool isJsonNumber(_In_ PWSTR str);
+    static bool isJsonNumber(_In_ std::wstring& str);
 
     static void SanitizeJson(_Inout_ std::wstring& str);
 };


### PR DESCRIPTION
Other output formats can now just be plugged at line 816 with a switch:

![image](https://user-images.githubusercontent.com/261265/220048499-c990f516-a62d-421e-93bc-bf964bf40122.png)

/cc. @charitykathure