### PR TITLE
fix: work-around for multi-byte characters

### DIFF
--- a/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
@@ -328,7 +328,7 @@ DWORD ReadFromPipe(LPVOID Param)
         size_t count = 0;
         size_t lastNewline = 0;
         clearBuffer(chBufOut);
-        while (*ptr > 0 && count < BUFSIZE) {
+        while (*ptr != '\0' && count < BUFSIZE) {
             // copy over to chBufOut till \r\n
             // the remaining will be reserved to be completed
             // by the next read.
@@ -351,7 +351,12 @@ DWORD ReadFromPipe(LPVOID Param)
                 }
             }
             else {
-                chBufOut[outSz++] = *ptr;
+                // no support for multibyte characters for now
+                // TODO(nandaa): https://github.com/microsoft/windows-container-tools/issues/121
+                if (*ptr < 0) {
+                    chBufOut[outSz++] = '?';
+                }
+                else chBufOut[outSz++] = *ptr;
             }
             ptr++;
             count++;


### PR DESCRIPTION
See #121 for details; this is a stop-gap measure for the time being.


===
Coming from the monitored process through the `pipe`:
```
2023-02-27 03:50:18 - DEBUG: Unicode character 161:Â¡''
2023-02-27 03:50:18 - DEBUG: Unicode character 162:'Â¢'
2023-02-27 03:50:18 - DEBUG: Unicode character 163:'Â£'
2023-02-27 03:50:18 - DEBUG: Unicode character 164:'Â¤'
2023-02-27 03:50:18 - DEBUG: Unicode character 165:'Â¥'
2023-02-27 03:50:18 - DEBUG: Unicode character 166:'Â¦'
2023-02-27 03:50:18 - DEBUG: Unicode character 167:'Â§'
2023-02-27 03:50:18 - DEBUG: Unicode character 168:'Â¨'
2023-02-27 03:50:18 - DEBUG: Unicode character 169:'Â©'
2023-02-27 03:50:18 - DEBUG: Unicode character 170:'Âª'
2023-02-27 03:50:18 - DEBUG: Unicode character 171:'Â«'
2023-02-27 03:50:18 - DEBUG: Unicode character 172:'Â¬'
```
Our failover:

![image](https://user-images.githubusercontent.com/261265/221819956-09b3caa9-76c1-44fc-a1ae-74d7320e652f.png)
