### PR TITLE
Custom Log Format 

### DIFF
--- a/LogMonitor/LogMonitorTests/EtwMonitorTests.cpp
+++ b/LogMonitor/LogMonitorTests/EtwMonitorTests.cpp
@@ -74,7 +74,7 @@ namespace LogMonitorTests
                 ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
                 fflush(stdout);
 
-                EtwMonitor etwMonitor(etwProviders, L"json");
+                EtwMonitor etwMonitor(etwProviders, L"json", L"");
                 Sleep(WAIT_TIME_ETWMONITOR_START);
 
                 
@@ -168,7 +168,7 @@ namespace LogMonitorTests
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
             fflush(stdout);
 
-            EtwMonitor etwMonitor(etwProviders, L"json");
+            EtwMonitor etwMonitor(etwProviders, L"json", L"");
 
             //
             // It must find the provider, and start printing events.
@@ -203,7 +203,7 @@ namespace LogMonitorTests
             fflush(stdout);
 
 
-            std::function<void(void)> f1 = [&etwProviders] { EtwMonitor etwMonitor(etwProviders, L"json"); };
+            std::function<void(void)> f1 = [&etwProviders] { EtwMonitor etwMonitor(etwProviders, L"json", L""); };
             Assert::ExpectException<std::invalid_argument>(f1);
         }
 
@@ -223,7 +223,7 @@ namespace LogMonitorTests
             providerWithoutLevel.Keywords = 0;
 
             std::vector<ETWProvider> etwProviders = { providerWithLevel, providerWithoutLevel };
-            EtwMonitor etwMonitor(etwProviders, L"json");
+            EtwMonitor etwMonitor(etwProviders, L"json", L"");
 
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
             fflush(stdout);

--- a/LogMonitor/LogMonitorTests/EventMonitorTests.cpp
+++ b/LogMonitor/LogMonitorTests/EventMonitorTests.cpp
@@ -103,7 +103,7 @@ namespace LogMonitorTests
         {
             std::vector<EventLogChannel> eventChannels = { {L"Application", EventChannelLogLevel::Error} };
 
-            EventMonitor eventMonitor(eventChannels, true, false, L"json");
+            EventMonitor eventMonitor(eventChannels, true, false, L"json", L"");
             Sleep(WAIT_TIME_EVENTMONITOR_START);
 
             //
@@ -209,7 +209,7 @@ namespace LogMonitorTests
         {
             std::vector<EventLogChannel> eventChannels = { {L"Application", EventChannelLogLevel::Information} };
 
-            EventMonitor eventMonitor(eventChannels, true, false, L"json");
+            EventMonitor eventMonitor(eventChannels, true, false, L"json", L"");
             Sleep(WAIT_TIME_EVENTMONITOR_START);
 
             //
@@ -356,7 +356,7 @@ namespace LogMonitorTests
 
             Assert::AreEqual(0, WriteEvent(level, eventId, message));
 
-            EventMonitor eventMonitor(eventChannels, true, true, L"json");
+            EventMonitor eventMonitor(eventChannels, true, true, L"json", L"");
             Sleep(WAIT_TIME_EVENTMONITOR_START);
 
             {
@@ -382,7 +382,7 @@ namespace LogMonitorTests
         {
             std::vector<EventLogChannel> eventChannels = { {L"System", EventChannelLogLevel::Information} };
 
-            EventMonitor eventMonitor(eventChannels, false, false, L"json");
+            EventMonitor eventMonitor(eventChannels, false, false, L"json", L"");
             Sleep(WAIT_TIME_EVENTMONITOR_START);
 
             {

--- a/LogMonitor/LogMonitorTests/LogFileMonitorTests.cpp
+++ b/LogMonitor/LogMonitorTests/LogFileMonitorTests.cpp
@@ -176,7 +176,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json");
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json", L"");
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -224,7 +224,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json");
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json", L"");
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -292,7 +292,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json");
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json", L"");
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -395,7 +395,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json");
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json", L"");
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -570,7 +570,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json");
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json", L"");
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -675,7 +675,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json");
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json", L"");
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -794,7 +794,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json");
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json", L"");
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -984,7 +984,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json");
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, L"json", L"");
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //

--- a/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
+++ b/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
@@ -314,7 +314,7 @@ ReadSourceAttributes(
             //
             else if (_wcsnicmp(key.c_str(), JSON_TAG_DIRECTORY, _countof(JSON_TAG_DIRECTORY)) == 0
                 || _wcsnicmp(key.c_str(), JSON_TAG_FILTER, _countof(JSON_TAG_FILTER)) == 0
-                || _wcsnicmp(key.c_str(), JSON_TAG_LINE_LOG_FORMAT, _countof(JSON_TAG_LINE_LOG_FORMAT)) == 0)
+                || _wcsnicmp(key.c_str(), JSON_TAG_CUSTOM_LOG_FORMAT, _countof(JSON_TAG_CUSTOM_LOG_FORMAT)) == 0)
             {
                 Attributes[key] = new std::wstring(Parser.ParseStringValue());
             }

--- a/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
+++ b/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
@@ -310,9 +310,11 @@ ReadSourceAttributes(
             // These attributes are string type
             // * directory
             // * filter
+            // * lineLogFormat
             //
             else if (_wcsnicmp(key.c_str(), JSON_TAG_DIRECTORY, _countof(JSON_TAG_DIRECTORY)) == 0
-                || _wcsnicmp(key.c_str(), JSON_TAG_FILTER, _countof(JSON_TAG_FILTER)) == 0)
+                || _wcsnicmp(key.c_str(), JSON_TAG_FILTER, _countof(JSON_TAG_FILTER)) == 0
+                || _wcsnicmp(key.c_str(), JSON_TAG_LINE_LOG_FORMAT, _countof(JSON_TAG_LINE_LOG_FORMAT)) == 0)
             {
                 Attributes[key] = new std::wstring(Parser.ParseStringValue());
             }

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -847,14 +847,11 @@ EtwMonitor::PrintEvent(
         }
 
         std::wstring formattedEvent;
-        if (Utility::CompareWStrings(m_logFormat, L"JSON"))
-        {
+        if (Utility::CompareWStrings(m_logFormat, L"JSON")) {
             formattedEvent = etwJsonFormat(pLogEntry);
-        }
-        else if (Utility::CompareWStrings(m_logFormat, L"Line")) {
+        } else if (Utility::CompareWStrings(m_logFormat, L"Line")) {
             formattedEvent = FormatETWLineLog(m_lineLogFormat, pLogEntry);
-        }
-        else {
+        } else {
             formattedEvent = etwXMLFormat(pLogEntry);
         }
 
@@ -1466,26 +1463,24 @@ std::wstring EtwMonitor::EtwFieldsMapping(_In_ std::wstring etwFields, _Inout_ E
     return oss.str();
 }
 
-std::wstring EtwMonitor::FormatETWLineLog(_In_ std::wstring str, _Inout_ EtwLogEntry* pLogEntry)
+std::wstring EtwMonitor::FormatETWLineLog(_In_ std::wstring logLineFormat, _Inout_ EtwLogEntry* pLogEntry)
 {
     size_t i = 0, j = 1;
-    while (i < str.size()) {
-        auto sub = str.substr(i, j);
+    while (i < logLineFormat.size()) {
+        auto sub = logLineFormat.substr(i, j);
         auto sub_length = sub.size();
         if (sub[0] != '%' && sub[sub_length - 1] != '%') {
             j++, i++;
-        }
-        else if (sub[0] == '%' && sub[sub_length - 1] == '%' && sub_length != 1) {
+        } else if (sub[0] == '%' && sub[sub_length - 1] == '%' && sub_length != 1) {
             //substring found
             wstring neString = EtwFieldsMapping(sub.substr(1, sub_length - 2), pLogEntry);
-            str.replace(i, j, neString);
+            logLineFormat.replace(i, j, neString);
 
             i = i + neString.length(), j = 1;
-        }
-        else {
+        } else {
             j++;
         }
     }
 
-    return str;
+    return logLineFormat;
 }

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -823,7 +823,6 @@ EtwMonitor::PrintEvent(
     EtwLogEntry logEntry;
     EtwLogEntry* pLogEntry = &logEntry;
 
-    Utility util;
     try
     {
         status = FormatMetadata(EventRecord, EventInfo, pLogEntry);
@@ -831,7 +830,7 @@ EtwMonitor::PrintEvent(
         if (status != ERROR_SUCCESS)
         {
             logWriter.TraceError(
-                util.FormatString(L"Failed to format ETW event metadata. Error: %lu", status).c_str()
+                Utility::FormatString(L"Failed to format ETW event metadata. Error: %lu", status).c_str()
             );
             return status;
         }
@@ -842,16 +841,16 @@ EtwMonitor::PrintEvent(
         if (status != ERROR_SUCCESS)
         {
             logWriter.TraceError(
-                util.FormatString(L"Failed to format ETW event data. Error: %lu", status).c_str()
+                Utility::FormatString(L"Failed to format ETW event data. Error: %lu", status).c_str()
             );
             return status;
         }
 
         std::wstring formattedEvent;
-        if (util.CompareWStrings(m_logFormat, L"JSON")) {
+        if (Utility::CompareWStrings(m_logFormat, L"JSON")) {
             formattedEvent = etwJsonFormat(pLogEntry);
-        } else if (util.CompareWStrings(m_logFormat, L"Custom")) {
-            formattedEvent = util.FormatEventLineLog(m_customLogFormat, pLogEntry, pLogEntry->source);
+        } else if (Utility::CompareWStrings(m_logFormat, L"Custom")) {
+            formattedEvent = Utility::FormatEventLineLog(m_customLogFormat, pLogEntry, pLogEntry->source);
         } else {
             formattedEvent = etwXMLFormat(pLogEntry);
         }

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -1445,17 +1445,17 @@ EtwMonitor::RemoveTrailingSpace(
 std::wstring EtwMonitor::EtwFieldsMapping(_In_ std::wstring etwFields, _Inout_ EtwLogEntry* pLogEntry) 
 {
     std::wostringstream oss;
-    if (etwFields == L"TimeStamp") oss << pLogEntry->Time;
-    if (etwFields == L"Severity") oss << pLogEntry->Level;
-    if (etwFields == L"Source") oss << pLogEntry->source;
-    if (etwFields == L"ProviderId") oss << pLogEntry->ProviderId;
-    if (etwFields == L"ProviderName") oss << pLogEntry->ProviderName;
-    if (etwFields == L"DecodingSource") oss << pLogEntry->DecodingSource;
-    if (etwFields == L"ExecutionProcessId") oss << pLogEntry->ExecProcessId;
-    if (etwFields == L"ExecutionThreadId") oss << pLogEntry->ExecThreadId;
-    if (etwFields == L"Keyword") oss << pLogEntry->Keyword;
-    if (etwFields == L"EventId") oss << pLogEntry->EventId;
-    if (etwFields == L"EventData") {
+    if (Utility::CompareWStrings(etwFields, L"TimeStamp")) oss << pLogEntry->Time;
+    if (Utility::CompareWStrings(etwFields, L"Severity")) oss << pLogEntry->Level;
+    if (Utility::CompareWStrings(etwFields, L"Source")) oss << pLogEntry->source;
+    if (Utility::CompareWStrings(etwFields, L"ProviderId")) oss << pLogEntry->ProviderId;
+    if (Utility::CompareWStrings(etwFields, L"ProviderName")) oss << pLogEntry->ProviderName;
+    if (Utility::CompareWStrings(etwFields, L"DecodingSource")) oss << pLogEntry->DecodingSource;
+    if (Utility::CompareWStrings(etwFields, L"ExecutionProcessId")) oss << pLogEntry->ExecProcessId;
+    if (Utility::CompareWStrings(etwFields, L"ExecutionThreadId")) oss << pLogEntry->ExecThreadId;
+    if (Utility::CompareWStrings(etwFields, L"Keyword")) oss << pLogEntry->Keyword;
+    if (Utility::CompareWStrings(etwFields, L"EventId")) oss << pLogEntry->EventId;
+    if (Utility::CompareWStrings(etwFields, L"EventData")) {
         for (auto evtData : pLogEntry->EventData) {
             wstring key = evtData.first;
             wstring value = evtData.second;

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -31,10 +31,10 @@ static const std::wstring g_sessionName = L"Log Monitor ETW Session";
 EtwMonitor::EtwMonitor(
     _In_ const std::vector<ETWProvider>& Providers,
     _In_ std::wstring LogFormat,
-    _In_ std::wstring LineLogFormat
+    _In_ std::wstring CustomLogFormat
     ) :
     m_logFormat(LogFormat),
-    m_lineLogFormat(LineLogFormat)
+    m_customLogFormat(CustomLogFormat)
 {
     //
     // This is set as 'true' to stop processing events.
@@ -851,7 +851,7 @@ EtwMonitor::PrintEvent(
         if (util.CompareWStrings(m_logFormat, L"JSON")) {
             formattedEvent = etwJsonFormat(pLogEntry);
         } else if (util.CompareWStrings(m_logFormat, L"Custom")) {
-            formattedEvent = util.FormatEventLineLog(m_lineLogFormat, pLogEntry, pLogEntry->source);
+            formattedEvent = util.FormatEventLineLog(m_customLogFormat, pLogEntry, pLogEntry->source);
         } else {
             formattedEvent = etwXMLFormat(pLogEntry);
         }

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -30,9 +30,11 @@ static const std::wstring g_sessionName = L"Log Monitor ETW Session";
 
 EtwMonitor::EtwMonitor(
     _In_ const std::vector<ETWProvider>& Providers,
-    _In_ std::wstring LogFormat
+    _In_ std::wstring LogFormat,
+    _In_ std::wstring LineLogFormat
     ) :
-    m_logFormat(LogFormat)
+    m_logFormat(LogFormat),
+    m_lineLogFormat(LineLogFormat)
 {
     //
     // This is set as 'true' to stop processing events.

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -31,7 +31,7 @@ static const std::wstring g_sessionName = L"Log Monitor ETW Session";
 EtwMonitor::EtwMonitor(
     _In_ const std::vector<ETWProvider>& Providers,
     _In_ std::wstring LogFormat,
-    _In_ std::wstring CustomLogFormat
+    _In_ std::wstring CustomLogFormat = L""
     ) :
     m_logFormat(LogFormat),
     m_customLogFormat(CustomLogFormat)
@@ -847,12 +847,12 @@ EtwMonitor::PrintEvent(
         }
 
         std::wstring formattedEvent;
-        if (Utility::CompareWStrings(m_logFormat, L"JSON")) {
-            formattedEvent = etwJsonFormat(pLogEntry);
+        if (Utility::CompareWStrings(m_logFormat, L"XML")) {
+            formattedEvent = etwXMLFormat(pLogEntry);
         } else if (Utility::CompareWStrings(m_logFormat, L"Custom")) {
             formattedEvent = Utility::FormatEventLineLog(m_customLogFormat, pLogEntry, pLogEntry->source);
         } else {
-            formattedEvent = etwXMLFormat(pLogEntry);
+            formattedEvent = etwJsonFormat(pLogEntry);
         }
 
         logWriter.WriteConsoleLog(formattedEvent);

--- a/LogMonitor/src/LogMonitor/EtwMonitor.h
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.h
@@ -14,6 +14,7 @@ typedef LPTSTR(NTAPI* PIPV6ADDRTOSTRING)(
 // struct to hold the ETW logEntry data
 //
 struct EtwLogEntry {
+    std::wstring source;
     std::wstring Time;
     std::wstring ProviderId;
     std::wstring ProviderName;
@@ -150,4 +151,8 @@ private:
     inline void RemoveTrailingSpace(
         _In_ PEVENT_MAP_INFO MapInfo
     );
+
+    std::wstring EtwFieldsMapping(_In_ std::wstring etwFields, _Inout_ EtwLogEntry* pLogEntry);
+
+    std::wstring FormatETWLineLog(_In_ std::wstring str, _Inout_ EtwLogEntry* pLogEntry);
 };

--- a/LogMonitor/src/LogMonitor/EtwMonitor.h
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.h
@@ -41,6 +41,8 @@ public:
 
     ~EtwMonitor();
 
+    static std::wstring EtwFieldsMapping(_In_ std::wstring etwFields, _In_ void* pLogEntryData);
+
 private:
     static constexpr int ETW_MONITOR_THREAD_EXIT_MAX_WAIT_MILLIS = 5 * 1000;
 
@@ -151,8 +153,4 @@ private:
     inline void RemoveTrailingSpace(
         _In_ PEVENT_MAP_INFO MapInfo
     );
-
-    std::wstring EtwFieldsMapping(_In_ std::wstring etwFields, _Inout_ EtwLogEntry* pLogEntry);
-
-    std::wstring FormatETWLineLog(_In_ std::wstring logLineFormat, _Inout_ EtwLogEntry* pLogEntry);
 };

--- a/LogMonitor/src/LogMonitor/EtwMonitor.h
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.h
@@ -34,7 +34,8 @@ public:
 
     EtwMonitor(
         _In_ const std::vector<ETWProvider>& Providers,
-        _In_ std::wstring LogFormat
+        _In_ std::wstring LogFormat,
+        _In_ std::wstring LineLogFormat
     );
 
     ~EtwMonitor();
@@ -44,6 +45,7 @@ private:
 
     std::vector<ETWProvider> m_providersConfig;
     std::wstring m_logFormat;
+    std::wstring m_lineLogFormat;
     TRACEHANDLE m_startTraceHandle;
 
     //

--- a/LogMonitor/src/LogMonitor/EtwMonitor.h
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.h
@@ -154,5 +154,5 @@ private:
 
     std::wstring EtwFieldsMapping(_In_ std::wstring etwFields, _Inout_ EtwLogEntry* pLogEntry);
 
-    std::wstring FormatETWLineLog(_In_ std::wstring str, _Inout_ EtwLogEntry* pLogEntry);
+    std::wstring FormatETWLineLog(_In_ std::wstring logLineFormat, _Inout_ EtwLogEntry* pLogEntry);
 };

--- a/LogMonitor/src/LogMonitor/EtwMonitor.h
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.h
@@ -36,7 +36,7 @@ public:
     EtwMonitor(
         _In_ const std::vector<ETWProvider>& Providers,
         _In_ std::wstring LogFormat,
-        _In_ std::wstring LineLogFormat
+        _In_ std::wstring CustomLogFormat
     );
 
     ~EtwMonitor();
@@ -48,7 +48,7 @@ private:
 
     std::vector<ETWProvider> m_providersConfig;
     std::wstring m_logFormat;
-    std::wstring m_lineLogFormat;
+    std::wstring m_customLogFormat;
     TRACEHANDLE m_startTraceHandle;
 
     //

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -569,8 +569,7 @@ EventMonitor::PrintEvent(
                 std::wstring formattedEvent;
                 if (Utility::CompareWStrings(m_logFormat, L"Line")) {
                     formattedEvent = FormatEventLineLog(m_lineLogFormat, pLogEntry);
-                }
-                else {
+                } else {
                     std::wstring logFmt = L"<Log><Source>%s</Source><LogEntry><Time>%s</Time><Channel>%s</Channel><Level>%s</Level><EventId>%u</EventId><Message>%s</Message></LogEntry></Log>";
                     if (Utility::CompareWStrings(m_logFormat, L"JSON"))
                     {
@@ -747,26 +746,24 @@ std::wstring EventMonitor::EventFieldsMapping(_In_ std::wstring eventFields, _In
     return oss.str();
 }
 
-std::wstring EventMonitor::FormatEventLineLog(_In_ std::wstring str, _Inout_ EventLogEntry* pLogEntry)
+std::wstring EventMonitor::FormatEventLineLog(_In_ std::wstring logLineFormat, _Inout_ EventLogEntry* pLogEntry)
 {
     size_t i = 0, j = 1;
-    while (i < str.size()) {
-        auto sub = str.substr(i, j);
+    while (i < logLineFormat.size()) {
+        auto sub = logLineFormat.substr(i, j);
         auto sub_length = sub.size();
         if (sub[0] != '%' && sub[sub_length - 1] != '%') {
             j++, i++;
-        }
-        else if (sub[0] == '%' && sub[sub_length - 1] == '%' && sub_length != 1) {
+        } else if (sub[0] == '%' && sub[sub_length - 1] == '%' && sub_length != 1) {
             //substring found
             wstring neString = EventFieldsMapping(sub.substr(1, sub_length - 2), pLogEntry);
-            str.replace(i, j, neString);
+            logLineFormat.replace(i, j, neString);
 
             i = i + neString.length(), j = 1;
-        }
-        else {
+        } else {
             j++;
         }
     }
 
-    return str;
+    return logLineFormat;
 }

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -29,7 +29,7 @@ EventMonitor::EventMonitor(
     _In_ bool EventFormatMultiLine,
     _In_ bool StartAtOldestRecord,
     _In_ std::wstring LogFormat,
-    _In_ std::wstring CustomLogFormat
+    _In_ std::wstring CustomLogFormat = L""
     ) :
     m_eventChannels(EventChannels),
     m_eventFormatMultiLine(EventFormatMultiLine),
@@ -570,9 +570,11 @@ EventMonitor::PrintEvent(
                 if (Utility::CompareWStrings(m_logFormat, L"Custom")) {
                     formattedEvent = Utility::FormatEventLineLog(m_customLogFormat, pLogEntry, pLogEntry->source);
                 } else {
-                    std::wstring logFmt = L"<Log><Source>%s</Source><LogEntry><Time>%s</Time><Channel>%s</Channel><Level>%s</Level><EventId>%u</EventId><Message>%s</Message></LogEntry></Log>";
-                    if (Utility::CompareWStrings(m_logFormat, L"JSON"))
-                    {
+                    std::wstring logFmt;
+                    if (Utility::CompareWStrings(m_logFormat, L"XML")) {
+                        logFmt = L"<Log><Source>%s</Source><LogEntry><Time>%s</Time><Channel>%s</Channel><Level>%s</Level><EventId>%u</EventId><Message>%s</Message></LogEntry></Log>";
+                    }
+                    else {
                         logFmt = L"{\"Source\": \"%s\",\"LogEntry\": {\"Time\": \"%s\",\"Channel\": \"%s\",\"Level\": \"%s\",\"EventId\": %u,\"Message\": \"%s\"}}";;
                         // sanitize message
                         std::wstring msg(m_eventMessageBuffer.begin(), m_eventMessageBuffer.end());

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -415,7 +415,7 @@ EventMonitor::PrintEvent(
     EVT_HANDLE renderContext = NULL;
     EVT_HANDLE publisher = NULL;
 
-    // struct to hold the Etw log entry and later format print
+    // struct to hold the Event log entry and later format print
     EventLogEntry logEntry;
     EventLogEntry* pLogEntry = &logEntry;
 

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -568,7 +568,7 @@ EventMonitor::PrintEvent(
 
                 std::wstring formattedEvent;
                 if (Utility::CompareWStrings(m_logFormat, L"Line")) {
-                    formattedEvent = SanitizeLineLogFormat(m_lineLogFormat, pLogEntry);
+                    formattedEvent = FormatEventLineLog(m_lineLogFormat, pLogEntry);
                 }
                 else {
                     std::wstring logFmt = L"<Log><Source>%s</Source><LogEntry><Time>%s</Time><Channel>%s</Channel><Level>%s</Level><EventId>%u</EventId><Message>%s</Message></LogEntry></Log>";
@@ -735,8 +735,8 @@ Exit:
     }
 }
 
-std::wstring EventMonitor::EventFieldsMapping(_In_ std::wstring eventFields, _Inout_ EventLogEntry* pLogEntry) {
-
+std::wstring EventMonitor::EventFieldsMapping(_In_ std::wstring eventFields, _Inout_ EventLogEntry* pLogEntry) 
+{
     std::wostringstream oss;
     if (eventFields == L"TimeStamp") oss << pLogEntry->eventTime;
     if (eventFields == L"Severity") oss << pLogEntry->eventLevel;
@@ -747,17 +747,16 @@ std::wstring EventMonitor::EventFieldsMapping(_In_ std::wstring eventFields, _In
     return oss.str();
 }
 
-std::wstring EventMonitor::SanitizeLineLogFormat(_In_ std::wstring str, _Inout_ EventLogEntry* pLogEntry)
+std::wstring EventMonitor::FormatEventLineLog(_In_ std::wstring str, _Inout_ EventLogEntry* pLogEntry)
 {
-    //std::set<wstring> fields;
-    size_t i = 0, j = 1, ind = 0;
+    size_t i = 0, j = 1;
     while (i < str.size()) {
         auto sub = str.substr(i, j);
         auto sub_length = sub.size();
         if (sub[0] != '%' && sub[sub_length - 1] != '%') {
             j++, i++;
         }
-        else if (sub[0] == '%' && sub[sub_length - 1] == '%') {
+        else if (sub[0] == '%' && sub[sub_length - 1] == '%' && sub_length != 1) {
             //substring found
             wstring neString = EventFieldsMapping(sub.substr(1, sub_length - 2), pLogEntry);
             str.replace(i, j, neString);

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -419,8 +419,6 @@ EventMonitor::PrintEvent(
     EventLogEntry logEntry;
     EventLogEntry* pLogEntry = &logEntry;
 
-    Utility util;
-
     static constexpr LPCWSTR defaultValuePaths[] = {
         L"Event/System/Provider/@Name",
         L"Event/System/Channel",
@@ -496,7 +494,7 @@ EventMonitor::PrintEvent(
                 status = GetLastError();
 
                 logWriter.TraceError(
-                    util.FormatString(L"Failed to render event. Error: %lu", status).c_str()
+                    Utility::FormatString(L"Failed to render event. Error: %lu", status).c_str()
                 );
             }
         }
@@ -563,25 +561,25 @@ EventMonitor::PrintEvent(
             if (status == ERROR_SUCCESS)
             {
                 pLogEntry->source = L"EventLog";
-                pLogEntry->eventTime = util.FileTimeToString(fileTimeCreated);
+                pLogEntry->eventTime = Utility::FileTimeToString(fileTimeCreated);
                 pLogEntry->eventChannel = channelName;
                 pLogEntry->eventLevel = c_LevelToString[static_cast<UINT8>(level)];
                 pLogEntry->eventMessage = (LPWSTR)(&m_eventMessageBuffer[0]);
 
                 std::wstring formattedEvent;
-                if (util.CompareWStrings(m_logFormat, L"Custom")) {
-                    formattedEvent = util.FormatEventLineLog(m_customLogFormat, pLogEntry, pLogEntry->source);
+                if (Utility::CompareWStrings(m_logFormat, L"Custom")) {
+                    formattedEvent = Utility::FormatEventLineLog(m_customLogFormat, pLogEntry, pLogEntry->source);
                 } else {
                     std::wstring logFmt = L"<Log><Source>%s</Source><LogEntry><Time>%s</Time><Channel>%s</Channel><Level>%s</Level><EventId>%u</EventId><Message>%s</Message></LogEntry></Log>";
-                    if (util.CompareWStrings(m_logFormat, L"JSON"))
+                    if (Utility::CompareWStrings(m_logFormat, L"JSON"))
                     {
                         logFmt = L"{\"Source\": \"%s\",\"LogEntry\": {\"Time\": \"%s\",\"Channel\": \"%s\",\"Level\": \"%s\",\"EventId\": %u,\"Message\": \"%s\"}}";;
                         // sanitize message
                         std::wstring msg(m_eventMessageBuffer.begin(), m_eventMessageBuffer.end());
-                        util.SanitizeJson(msg);
+                        Utility::SanitizeJson(msg);
                     }
 
-                    formattedEvent = util.FormatString(
+                    formattedEvent = Utility::FormatString(
                         logFmt.c_str(),
                         pLogEntry->source.c_str(),
                         pLogEntry->eventTime.c_str(),

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -738,11 +738,11 @@ Exit:
 std::wstring EventMonitor::EventFieldsMapping(_In_ std::wstring eventFields, _Inout_ EventLogEntry* pLogEntry) 
 {
     std::wostringstream oss;
-    if (eventFields == L"TimeStamp") oss << pLogEntry->eventTime;
-    if (eventFields == L"Severity") oss << pLogEntry->eventLevel;
-    if (eventFields == L"Source") oss << pLogEntry->source;
-    if (eventFields == L"EventID") oss << pLogEntry->eventId;
-    if (eventFields == L"Message") oss << pLogEntry->eventMessage;
+    if (Utility::CompareWStrings(eventFields, L"TimeStamp")) oss << pLogEntry->eventTime;
+    if (Utility::CompareWStrings(eventFields, L"Severity")) oss << pLogEntry->eventLevel;
+    if (Utility::CompareWStrings(eventFields, L"Source")) oss << pLogEntry->source;
+    if (Utility::CompareWStrings(eventFields, L"EventID")) oss << pLogEntry->eventId;
+    if (Utility::CompareWStrings(eventFields, L"Message")) oss << pLogEntry->eventMessage;
 
     return oss.str();
 }

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -29,13 +29,13 @@ EventMonitor::EventMonitor(
     _In_ bool EventFormatMultiLine,
     _In_ bool StartAtOldestRecord,
     _In_ std::wstring LogFormat,
-    _In_ std::wstring LineLogFormat
+    _In_ std::wstring CustomLogFormat
     ) :
     m_eventChannels(EventChannels),
     m_eventFormatMultiLine(EventFormatMultiLine),
     m_startAtOldestRecord(StartAtOldestRecord),
     m_logFormat(LogFormat),
-    m_lineLogFormat(LineLogFormat)
+    m_customLogFormat(CustomLogFormat)
 {
     m_stopEvent = NULL;
     m_eventMonitorThread = NULL;
@@ -570,7 +570,7 @@ EventMonitor::PrintEvent(
 
                 std::wstring formattedEvent;
                 if (util.CompareWStrings(m_logFormat, L"Custom")) {
-                    formattedEvent = util.FormatEventLineLog(m_lineLogFormat, pLogEntry, pLogEntry->source);
+                    formattedEvent = util.FormatEventLineLog(m_customLogFormat, pLogEntry, pLogEntry->source);
                 } else {
                     std::wstring logFmt = L"<Log><Source>%s</Source><LogEntry><Time>%s</Time><Channel>%s</Channel><Level>%s</Level><EventId>%u</EventId><Message>%s</Message></LogEntry></Log>";
                     if (util.CompareWStrings(m_logFormat, L"JSON"))

--- a/LogMonitor/src/LogMonitor/EventMonitor.h
+++ b/LogMonitor/src/LogMonitor/EventMonitor.h
@@ -15,7 +15,7 @@ public:
         _In_ bool EventFormatMultiLine,
         _In_ bool StartAtOldestRecord,
         _In_ std::wstring LogFormat,
-        _In_ std::wstring LineLogFormat
+        _In_ std::wstring CustomLogFormat
         );
 
     ~EventMonitor();
@@ -30,7 +30,7 @@ private:
     bool m_eventFormatMultiLine;
     bool m_startAtOldestRecord;
     std::wstring m_logFormat;
-    std::wstring m_lineLogFormat;
+    std::wstring m_customLogFormat;
 
     struct EventLogEntry {
         std::wstring source;

--- a/LogMonitor/src/LogMonitor/EventMonitor.h
+++ b/LogMonitor/src/LogMonitor/EventMonitor.h
@@ -20,6 +20,8 @@ public:
 
     ~EventMonitor();
 
+    static std::wstring EventFieldsMapping(_In_ std::wstring eventField, _In_ void* pLogEntryData);
+
 private:
     static constexpr int EVENT_MONITOR_THREAD_EXIT_MAX_WAIT_MILLIS = 5 * 1000;
     static constexpr int EVENT_ARRAY_SIZE = 10;
@@ -68,10 +70,6 @@ private:
     DWORD PrintEvent(
         _In_ const HANDLE& EventHandle
         );
-
-    std::wstring EventFieldsMapping(_In_ std::wstring eventFields, _Inout_ EventLogEntry* pLogEntry);
-
-    std::wstring FormatEventLineLog(_In_ std::wstring logLineFormat, _Inout_ EventLogEntry* pLogEntry);
 
     void EnableEventLogChannels();
 

--- a/LogMonitor/src/LogMonitor/EventMonitor.h
+++ b/LogMonitor/src/LogMonitor/EventMonitor.h
@@ -71,7 +71,7 @@ private:
 
     std::wstring EventFieldsMapping(_In_ std::wstring eventFields, _Inout_ EventLogEntry* pLogEntry);
 
-    std::wstring SanitizeLineLogFormat(_In_ std::wstring str, _Inout_ EventLogEntry* pLogEntry);
+    std::wstring FormatEventLineLog(_In_ std::wstring str, _Inout_ EventLogEntry* pLogEntry);
 
     void EnableEventLogChannels();
 

--- a/LogMonitor/src/LogMonitor/EventMonitor.h
+++ b/LogMonitor/src/LogMonitor/EventMonitor.h
@@ -14,7 +14,8 @@ public:
         _In_ const std::vector<EventLogChannel>& eventChannels,
         _In_ bool EventFormatMultiLine,
         _In_ bool StartAtOldestRecord,
-        _In_ std::wstring LogFormat
+        _In_ std::wstring LogFormat,
+        _In_ std::wstring LineLogFormat
         );
 
     ~EventMonitor();
@@ -27,13 +28,16 @@ private:
     bool m_eventFormatMultiLine;
     bool m_startAtOldestRecord;
     std::wstring m_logFormat;
+    std::wstring m_lineLogFormat;
 
-    std::wstring source;
-    std::wstring eventTime;
-    std::wstring eventChannel;
-    std::wstring eventLevel;
-    UINT16 eventId;
-    std::wstring eventMessage;
+    struct EventLogEntry {
+        std::wstring source;
+        std::wstring eventTime;
+        std::wstring eventChannel;
+        std::wstring eventLevel;
+        UINT16 eventId;
+        std::wstring eventMessage;
+    };
 
     //
     // Signaled by destructor to request the spawned thread to stop.
@@ -64,6 +68,10 @@ private:
     DWORD PrintEvent(
         _In_ const HANDLE& EventHandle
         );
+
+    std::wstring EventFieldsMapping(_In_ std::wstring eventFields, _Inout_ EventLogEntry* pLogEntry);
+
+    std::wstring SanitizeLineLogFormat(_In_ std::wstring str, _Inout_ EventLogEntry* pLogEntry);
 
     void EnableEventLogChannels();
 

--- a/LogMonitor/src/LogMonitor/EventMonitor.h
+++ b/LogMonitor/src/LogMonitor/EventMonitor.h
@@ -71,7 +71,7 @@ private:
 
     std::wstring EventFieldsMapping(_In_ std::wstring eventFields, _Inout_ EventLogEntry* pLogEntry);
 
-    std::wstring FormatEventLineLog(_In_ std::wstring str, _Inout_ EventLogEntry* pLogEntry);
+    std::wstring FormatEventLineLog(_In_ std::wstring logLineFormat, _Inout_ EventLogEntry* pLogEntry);
 
     void EnableEventLogChannels();
 

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -40,12 +40,14 @@ using namespace std;
 LogFileMonitor::LogFileMonitor(_In_ const std::wstring& LogDirectory,
                                _In_ const std::wstring& Filter,
                                _In_ bool IncludeSubfolders,
-                               _In_ std::wstring LogFormat
+                               _In_ std::wstring LogFormat,
+                               _In_ std::wstring LineLogFormat
                                ) :
                                m_logDirectory(LogDirectory),
                                m_filter(Filter),
                                m_includeSubfolders(IncludeSubfolders),
-                               m_logFormat(LogFormat)
+                               m_logFormat(LogFormat),
+                               m_lineLogFormat(LineLogFormat)
 {
     m_stopEvent = NULL;
     m_overlappedEvent = NULL;

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1687,10 +1687,8 @@ void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstrin
     SYSTEMTIME st;
     GetSystemTime(&st);
 
-    Utility util;
-
     pLogEntry->source = L"File";
-    pLogEntry->currentTime = util.SystemTimeToString(st).c_str();
+    pLogEntry->currentTime = Utility::SystemTimeToString(st).c_str();
 
     while (true) {
         i = Message.find(L"\n", start);
@@ -1710,23 +1708,23 @@ void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstrin
         // ignore empty lines
         if (msg.size() > 0) {
             // escape backslashes in FileName
-            auto fmtFileName = util.ReplaceAll(FileName, L"\\", L"\\\\");
+            auto fmtFileName = Utility::ReplaceAll(FileName, L"\\", L"\\\\");
             pLogEntry->fileName = fmtFileName;
             pLogEntry->message = msg;
 
             std::wstring formattedFileEntry;
-            if (util.CompareWStrings(m_logFormat, L"Custom")) {
-                formattedFileEntry = util.FormatEventLineLog(m_customLogFormat, pLogEntry, pLogEntry->source);
+            if (Utility::CompareWStrings(m_logFormat, L"Custom")) {
+                formattedFileEntry = Utility::FormatEventLineLog(m_customLogFormat, pLogEntry, pLogEntry->source);
             } else {
                 std::wstring logFmt = L"<Log><Source>File</Source><LogEntry><Logline>%s</Logline><FileName>%s</FileName></LogEntry></Log>";
-                if (util.CompareWStrings(m_logFormat, L"JSON"))
+                if (Utility::CompareWStrings(m_logFormat, L"JSON"))
                 {
                     logFmt = L"{\"Source\": \"File\",\"LogEntry\": {\"Logline\": \"%s\",\"FileName\": \"%s\"},\"SchemaVersion\":\"1.0.0\"}";
                     // sanitize message
-                    util.SanitizeJson(msg);
+                    Utility::SanitizeJson(msg);
                 }
 
-                formattedFileEntry = util.FormatString(
+                formattedFileEntry = Utility::FormatString(
                     logFmt.c_str(), 
                     pLogEntry->message.c_str(), 
                     pLogEntry->fileName.c_str()

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -41,7 +41,7 @@ LogFileMonitor::LogFileMonitor(_In_ const std::wstring& LogDirectory,
                                _In_ const std::wstring& Filter,
                                _In_ bool IncludeSubfolders,
                                _In_ std::wstring LogFormat,
-                               _In_ std::wstring CustomLogFormat
+                               _In_ std::wstring CustomLogFormat = L""
                                ) :
                                m_logDirectory(LogDirectory),
                                m_filter(Filter),
@@ -1716,9 +1716,11 @@ void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstrin
             if (Utility::CompareWStrings(m_logFormat, L"Custom")) {
                 formattedFileEntry = Utility::FormatEventLineLog(m_customLogFormat, pLogEntry, pLogEntry->source);
             } else {
-                std::wstring logFmt = L"<Log><Source>File</Source><LogEntry><Logline>%s</Logline><FileName>%s</FileName></LogEntry></Log>";
-                if (Utility::CompareWStrings(m_logFormat, L"JSON"))
-                {
+                std::wstring logFmt;
+                if (Utility::CompareWStrings(m_logFormat, L"XML")) {
+                    logFmt = L"<Log><Source>File</Source><LogEntry><Logline>%s</Logline><FileName>%s</FileName></LogEntry></Log>";
+                }
+                else {
                     logFmt = L"{\"Source\": \"File\",\"LogEntry\": {\"Logline\": \"%s\",\"FileName\": \"%s\"},\"SchemaVersion\":\"1.0.0\"}";
                     // sanitize message
                     Utility::SanitizeJson(msg);

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -2073,10 +2073,10 @@ LogFileMonitor::GetFileId(
 std::wstring LogFileMonitor::FileFieldsMapping(_In_ std::wstring fileFields, _Inout_ FileLogEntry* pLogEntry)
 {
     std::wostringstream oss;
-    if (fileFields == L"TimeStamp") oss << pLogEntry->currentTime;
-    if (fileFields == L"FileName") oss << pLogEntry->fileName;
-    if (fileFields == L"Source") oss << pLogEntry->source;
-    if (fileFields == L"Message") oss << pLogEntry->message;
+    if (Utility::CompareWStrings(fileFields, L"TimeStamp")) oss << pLogEntry->currentTime;
+    if (Utility::CompareWStrings(fileFields, L"FileName")) oss << pLogEntry->fileName;
+    if (Utility::CompareWStrings(fileFields, L"Source")) oss << pLogEntry->source;
+    if (Utility::CompareWStrings(fileFields, L"Message")) oss << pLogEntry->message;
 
     return oss.str();
 }

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -41,13 +41,13 @@ LogFileMonitor::LogFileMonitor(_In_ const std::wstring& LogDirectory,
                                _In_ const std::wstring& Filter,
                                _In_ bool IncludeSubfolders,
                                _In_ std::wstring LogFormat,
-                               _In_ std::wstring LineLogFormat
+                               _In_ std::wstring CustomLogFormat
                                ) :
                                m_logDirectory(LogDirectory),
                                m_filter(Filter),
                                m_includeSubfolders(IncludeSubfolders),
                                m_logFormat(LogFormat),
-                               m_lineLogFormat(LineLogFormat)
+                               m_customLogFormat(CustomLogFormat)
 {
     m_stopEvent = NULL;
     m_overlappedEvent = NULL;
@@ -1716,7 +1716,7 @@ void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstrin
 
             std::wstring formattedFileEntry;
             if (util.CompareWStrings(m_logFormat, L"Custom")) {
-                formattedFileEntry = util.FormatEventLineLog(m_lineLogFormat, pLogEntry, pLogEntry->source);
+                formattedFileEntry = util.FormatEventLineLog(m_customLogFormat, pLogEntry, pLogEntry->source);
             } else {
                 std::wstring logFmt = L"<Log><Source>File</Source><LogEntry><Logline>%s</Logline><FileName>%s</FileName></LogEntry></Log>";
                 if (util.CompareWStrings(m_logFormat, L"JSON"))

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1715,8 +1715,7 @@ void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstrin
             std::wstring formattedFileEntry;
             if (Utility::CompareWStrings(m_logFormat, L"Line")) {
                 formattedFileEntry = FormatFileLineLog(m_lineLogFormat, pLogEntry);
-            }
-            else {
+            } else {
                 std::wstring logFmt = L"<Log><Source>File</Source><LogEntry><Logline>%s</Logline><FileName>%s</FileName></LogEntry></Log>";
                 if (Utility::CompareWStrings(m_logFormat, L"JSON"))
                 {
@@ -2081,26 +2080,24 @@ std::wstring LogFileMonitor::FileFieldsMapping(_In_ std::wstring fileFields, _In
     return oss.str();
 }
 
-std::wstring LogFileMonitor::FormatFileLineLog(_In_ std::wstring str, _Inout_ FileLogEntry* pLogEntry)
+std::wstring LogFileMonitor::FormatFileLineLog(_In_ std::wstring logLineFormat, _Inout_ FileLogEntry* pLogEntry)
 {
     size_t i = 0, j = 1;
-    while (i < str.size()) {
-        auto sub = str.substr(i, j);
+    while (i < logLineFormat.size()) {
+        auto sub = logLineFormat.substr(i, j);
         auto sub_length = sub.size();
         if (sub[0] != '%' && sub[sub_length - 1] != '%') {
             j++, i++;
-        }
-        else if (sub[0] == '%' && sub[sub_length - 1] == '%' && sub_length != 1) {
+        } else if (sub[0] == '%' && sub[sub_length - 1] == '%' && sub_length != 1) {
             //substring found
             wstring neString = FileFieldsMapping(sub.substr(1, sub_length - 2), pLogEntry);
-            str.replace(i, j, neString);
+            logLineFormat.replace(i, j, neString);
 
             i = i + neString.length(), j = 1;
-        }
-        else {
+        } else {
             j++;
         }
     }
 
-    return str;
+    return logLineFormat;
 }

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.h
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.h
@@ -61,7 +61,8 @@ public:
         _In_ const std::wstring& LogDirectory,
         _In_ const std::wstring& Filter,
         _In_ bool IncludeSubfolders,
-        _In_ std::wstring LogFormat
+        _In_ std::wstring LogFormat,
+        _In_ std::wstring LineLogFormat
         );
 
     ~LogFileMonitor();
@@ -75,6 +76,7 @@ private:
     std::wstring m_filter;
     bool m_includeSubfolders;
     std::wstring m_logFormat;
+    std::wstring m_lineLogFormat;
 
     //
     // Signaled by destructor to request the spawned thread to stop.

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.h
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.h
@@ -62,7 +62,7 @@ public:
         _In_ const std::wstring& Filter,
         _In_ bool IncludeSubfolders,
         _In_ std::wstring LogFormat,
-        _In_ std::wstring LineLogFormat
+        _In_ std::wstring CustomLogFormat
         );
 
     ~LogFileMonitor();
@@ -78,7 +78,7 @@ private:
     std::wstring m_filter;
     bool m_includeSubfolders;
     std::wstring m_logFormat;
-    std::wstring m_lineLogFormat;
+    std::wstring m_customLogFormat;
 
     struct FileLogEntry {
         std::wstring source;

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.h
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.h
@@ -236,5 +236,5 @@ private:
 
     std::wstring FileFieldsMapping(_In_ std::wstring eventFields, _Inout_ FileLogEntry* pLogEntry);
 
-    std::wstring FormatFileLineLog(_In_ std::wstring str, _Inout_ FileLogEntry* pLogEntry);
+    std::wstring FormatFileLineLog(_In_ std::wstring logLineFormat, _Inout_ FileLogEntry* pLogEntry);
 };

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.h
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.h
@@ -67,6 +67,8 @@ public:
 
     ~LogFileMonitor();
 
+    static std::wstring FileFieldsMapping(_In_ std::wstring eventFields, _In_ void* pLogEntryData);
+
 private:
     static constexpr int LOG_MONITOR_THREAD_EXIT_MAX_WAIT_MILLIS = 5 * 1000;
     static constexpr int RECORDS_BUFFER_SIZE_BYTES = 8 * 1024;
@@ -233,8 +235,4 @@ private:
         _Out_ FILE_ID_INFO& FileId,
         _In_opt_ HANDLE Handle = INVALID_HANDLE_VALUE
         );
-
-    std::wstring FileFieldsMapping(_In_ std::wstring eventFields, _Inout_ FileLogEntry* pLogEntry);
-
-    std::wstring FormatFileLineLog(_In_ std::wstring logLineFormat, _Inout_ FileLogEntry* pLogEntry);
 };

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.h
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.h
@@ -78,6 +78,13 @@ private:
     std::wstring m_logFormat;
     std::wstring m_lineLogFormat;
 
+    struct FileLogEntry {
+        std::wstring source;
+        std::wstring currentTime;
+        std::wstring fileName;
+        std::wstring message;
+    };
+
     //
     // Signaled by destructor to request the spawned thread to stop.
     //
@@ -226,4 +233,8 @@ private:
         _Out_ FILE_ID_INFO& FileId,
         _In_opt_ HANDLE Handle = INVALID_HANDLE_VALUE
         );
+
+    std::wstring FileFieldsMapping(_In_ std::wstring eventFields, _Inout_ FileLogEntry* pLogEntry);
+
+    std::wstring FormatFileLineLog(_In_ std::wstring str, _Inout_ FileLogEntry* pLogEntry);
 };

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -85,7 +85,8 @@ void StartMonitors(_In_ LoggerSettings& settings)
     bool eventMonStartAtOldestRecord;
     bool etwMonMultiLine;
     std::wstring logFormat = settings.LogFormat;
-    std::wstring lineLogFormat;
+    std::wstring eventLineLogFormat;
+    std::wstring etwLineLogFormat;
 
     for (auto source : settings.Sources)
     {
@@ -103,7 +104,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
 
                 eventMonMultiLine = sourceEventLog->EventFormatMultiLine;
                 eventMonStartAtOldestRecord = sourceEventLog->StartAtOldestRecord;
-                lineLogFormat = sourceEventLog->LineLogFormat;
+                eventLineLogFormat = sourceEventLog->LineLogFormat;
 
                 break;
             }
@@ -154,7 +155,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
                 }
 
                 etwMonMultiLine = sourceETW->EventFormatMultiLine;
-                lineLogFormat = sourceETW->LineLogFormat;
+                etwLineLogFormat = sourceETW->LineLogFormat;
 
                 break;
             }
@@ -165,7 +166,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
     {
         try
         {
-            g_eventMon = make_unique<EventMonitor>(eventChannels, eventMonMultiLine, eventMonStartAtOldestRecord, logFormat, lineLogFormat);
+            g_eventMon = make_unique<EventMonitor>(eventChannels, eventMonMultiLine, eventMonStartAtOldestRecord, logFormat, eventLineLogFormat);
         }
         catch (std::exception& ex)
         {
@@ -190,7 +191,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
     {
         try
         {
-            g_etwMon = make_unique<EtwMonitor>(etwProviders, logFormat, lineLogFormat);
+            g_etwMon = make_unique<EtwMonitor>(etwProviders, logFormat, etwLineLogFormat);
         }
         catch (...)
         {

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -85,6 +85,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
     bool eventMonStartAtOldestRecord;
     bool etwMonMultiLine;
     std::wstring logFormat = settings.LogFormat;
+    std::wstring lineLogFormat;
 
     for (auto source : settings.Sources)
     {
@@ -102,6 +103,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
 
                 eventMonMultiLine = sourceEventLog->EventFormatMultiLine;
                 eventMonStartAtOldestRecord = sourceEventLog->StartAtOldestRecord;
+                lineLogFormat = sourceEventLog->LineLogFormat;
 
                 break;
             }
@@ -115,7 +117,8 @@ void StartMonitors(_In_ LoggerSettings& settings)
                         sourceFile->Directory,
                         sourceFile->Filter,
                         sourceFile->IncludeSubdirectories,
-                        logFormat
+                        logFormat,
+                        sourceFile->LineLogFormat
                     );
                     g_logfileMonitors.push_back(std::move(logfileMon));
                 }
@@ -151,6 +154,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
                 }
 
                 etwMonMultiLine = sourceETW->EventFormatMultiLine;
+                lineLogFormat = sourceETW->LineLogFormat;
 
                 break;
             }
@@ -161,7 +165,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
     {
         try
         {
-            g_eventMon = make_unique<EventMonitor>(eventChannels, eventMonMultiLine, eventMonStartAtOldestRecord, logFormat);
+            g_eventMon = make_unique<EventMonitor>(eventChannels, eventMonMultiLine, eventMonStartAtOldestRecord, logFormat, lineLogFormat);
         }
         catch (std::exception& ex)
         {
@@ -186,7 +190,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
     {
         try
         {
-            g_etwMon = make_unique<EtwMonitor>(etwProviders, logFormat);
+            g_etwMon = make_unique<EtwMonitor>(etwProviders, logFormat, lineLogFormat);
         }
         catch (...)
         {

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -85,8 +85,8 @@ void StartMonitors(_In_ LoggerSettings& settings)
     bool eventMonStartAtOldestRecord;
     bool etwMonMultiLine;
     std::wstring logFormat = settings.LogFormat;
-    std::wstring eventLineLogFormat;
-    std::wstring etwLineLogFormat;
+    std::wstring eventCustomLogFormat;
+    std::wstring etwCustomLogFormat;
 
     for (auto source : settings.Sources)
     {
@@ -104,7 +104,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
 
                 eventMonMultiLine = sourceEventLog->EventFormatMultiLine;
                 eventMonStartAtOldestRecord = sourceEventLog->StartAtOldestRecord;
-                eventLineLogFormat = sourceEventLog->LineLogFormat;
+                eventCustomLogFormat = sourceEventLog->CustomLogFormat;
 
                 break;
             }
@@ -119,7 +119,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
                         sourceFile->Filter,
                         sourceFile->IncludeSubdirectories,
                         logFormat,
-                        sourceFile->LineLogFormat
+                        sourceFile->CustomLogFormat
                     );
                     g_logfileMonitors.push_back(std::move(logfileMon));
                 }
@@ -155,7 +155,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
                 }
 
                 etwMonMultiLine = sourceETW->EventFormatMultiLine;
-                etwLineLogFormat = sourceETW->LineLogFormat;
+                etwCustomLogFormat = sourceETW->CustomLogFormat;
 
                 break;
             }
@@ -166,7 +166,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
     {
         try
         {
-            g_eventMon = make_unique<EventMonitor>(eventChannels, eventMonMultiLine, eventMonStartAtOldestRecord, logFormat, eventLineLogFormat);
+            g_eventMon = make_unique<EventMonitor>(eventChannels, eventMonMultiLine, eventMonStartAtOldestRecord, logFormat, eventCustomLogFormat);
         }
         catch (std::exception& ex)
         {
@@ -191,7 +191,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
     {
         try
         {
-            g_etwMon = make_unique<EtwMonitor>(etwProviders, logFormat, etwLineLogFormat);
+            g_etwMon = make_unique<EtwMonitor>(etwProviders, logFormat, etwCustomLogFormat);
         }
         catch (...)
         {

--- a/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
+++ b/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
@@ -208,7 +208,7 @@ public:
     std::vector<EventLogChannel> Channels;
     bool EventFormatMultiLine = true;
     bool StartAtOldestRecord = false;
-    std::wstring LineLogFormat;
+    std::wstring LineLogFormat = L"[%TimeStamp%] [%Source%] [%Severity%] %Message%";
 
     static bool Unwrap(
         _In_ AttributesMap& Attributes,
@@ -270,7 +270,7 @@ public:
     std::wstring Directory;
     std::wstring Filter;
     bool IncludeSubdirectories = false;
-    std::wstring LineLogFormat;
+    std::wstring LineLogFormat = L"[%TimeStamp%] [%Source%] [%FileName%] %Message%";
 
     static bool Unwrap(
         _In_ AttributesMap& Attributes,
@@ -385,7 +385,7 @@ class SourceETW : LogSource
 public:
     std::vector<ETWProvider> Providers;
     bool EventFormatMultiLine = true;
-    std::wstring LineLogFormat;
+    std::wstring LineLogFormat = L"[%TimeStamp%] [%Source%] [%Severity%] [%ProviderId%] [%ProviderName%] [%EventId%] %EventData%";
 
     static bool Unwrap(
         _In_ AttributesMap& Attributes,

--- a/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
+++ b/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
@@ -14,6 +14,7 @@
 /// Log formatting attributes
 /// 
 #define JSON_TAG_LOG_FORMAT L"logFormat"
+#define JSON_TAG_LINE_LOG_FORMAT L"lineLogFormat"
 
 ///
 /// Valid source attributes
@@ -207,6 +208,7 @@ public:
     std::vector<EventLogChannel> Channels;
     bool EventFormatMultiLine = true;
     bool StartAtOldestRecord = false;
+    std::wstring LineLogFormat;
 
     static bool Unwrap(
         _In_ AttributesMap& Attributes,
@@ -246,6 +248,15 @@ public:
             NewSource.StartAtOldestRecord = *(bool*)Attributes[JSON_TAG_START_AT_OLDEST_RECORD];
         }
 
+        //
+        // lineLogFormat is an optional value
+        //
+        if (Attributes.find(JSON_TAG_LINE_LOG_FORMAT) != Attributes.end()
+            && Attributes[JSON_TAG_LINE_LOG_FORMAT] != nullptr)
+        {
+            NewSource.LineLogFormat = *(std::wstring*)Attributes[JSON_TAG_LINE_LOG_FORMAT];
+        }
+
         return true;
     }
 };
@@ -259,6 +270,7 @@ public:
     std::wstring Directory;
     std::wstring Filter;
     bool IncludeSubdirectories = false;
+    std::wstring LineLogFormat;
 
     static bool Unwrap(
         _In_ AttributesMap& Attributes,
@@ -296,6 +308,15 @@ public:
             && Attributes[JSON_TAG_INCLUDE_SUBDIRECTORIES] != nullptr)
         {
             NewSource.IncludeSubdirectories = *(bool*)Attributes[JSON_TAG_INCLUDE_SUBDIRECTORIES];
+        }
+
+        //
+        // lineLogFormat is an optional value
+        //
+        if (Attributes.find(JSON_TAG_LINE_LOG_FORMAT) != Attributes.end()
+            && Attributes[JSON_TAG_LINE_LOG_FORMAT] != nullptr)
+        {
+            NewSource.LineLogFormat = *(std::wstring*)Attributes[JSON_TAG_LINE_LOG_FORMAT];
         }
 
         return true;
@@ -364,6 +385,7 @@ class SourceETW : LogSource
 public:
     std::vector<ETWProvider> Providers;
     bool EventFormatMultiLine = true;
+    std::wstring LineLogFormat;
 
     static bool Unwrap(
         _In_ AttributesMap& Attributes,
@@ -392,6 +414,15 @@ public:
             && Attributes[JSON_TAG_FORMAT_MULTILINE] != nullptr)
         {
             NewSource.EventFormatMultiLine = *(bool*)Attributes[JSON_TAG_FORMAT_MULTILINE];
+        }
+
+        //
+        // lineLogFormat is an optional value
+        //
+        if (Attributes.find(JSON_TAG_LINE_LOG_FORMAT) != Attributes.end()
+            && Attributes[JSON_TAG_LINE_LOG_FORMAT] != nullptr)
+        {
+            NewSource.LineLogFormat = *(std::wstring*)Attributes[JSON_TAG_LINE_LOG_FORMAT];
         }
 
 

--- a/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
+++ b/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
@@ -436,5 +436,5 @@ public:
 typedef struct _LoggerSettings
 {
     std::vector<std::shared_ptr<LogSource> > Sources;
-    std::wstring LogFormat = L"XML";
+    std::wstring LogFormat = L"JSON";
 } LoggerSettings;

--- a/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
+++ b/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
@@ -14,7 +14,7 @@
 /// Log formatting attributes
 /// 
 #define JSON_TAG_LOG_FORMAT L"logFormat"
-#define JSON_TAG_LINE_LOG_FORMAT L"lineLogFormat"
+#define JSON_TAG_CUSTOM_LOG_FORMAT L"customLogFormat"
 
 ///
 /// Valid source attributes
@@ -208,7 +208,7 @@ public:
     std::vector<EventLogChannel> Channels;
     bool EventFormatMultiLine = true;
     bool StartAtOldestRecord = false;
-    std::wstring LineLogFormat = L"[%TimeStamp%] [%Source%] [%Severity%] %Message%";
+    std::wstring CustomLogFormat = L"[%TimeStamp%] [%Source%] [%Severity%] %Message%";
 
     static bool Unwrap(
         _In_ AttributesMap& Attributes,
@@ -251,10 +251,10 @@ public:
         //
         // lineLogFormat is an optional value
         //
-        if (Attributes.find(JSON_TAG_LINE_LOG_FORMAT) != Attributes.end()
-            && Attributes[JSON_TAG_LINE_LOG_FORMAT] != nullptr)
+        if (Attributes.find(JSON_TAG_CUSTOM_LOG_FORMAT) != Attributes.end()
+            && Attributes[JSON_TAG_CUSTOM_LOG_FORMAT] != nullptr)
         {
-            NewSource.LineLogFormat = *(std::wstring*)Attributes[JSON_TAG_LINE_LOG_FORMAT];
+            NewSource.CustomLogFormat = *(std::wstring*)Attributes[JSON_TAG_CUSTOM_LOG_FORMAT];
         }
 
         return true;
@@ -270,7 +270,7 @@ public:
     std::wstring Directory;
     std::wstring Filter;
     bool IncludeSubdirectories = false;
-    std::wstring LineLogFormat = L"[%TimeStamp%] [%Source%] [%FileName%] %Message%";
+    std::wstring CustomLogFormat = L"[%TimeStamp%] [%Source%] [%FileName%] %Message%";
 
     static bool Unwrap(
         _In_ AttributesMap& Attributes,
@@ -313,10 +313,10 @@ public:
         //
         // lineLogFormat is an optional value
         //
-        if (Attributes.find(JSON_TAG_LINE_LOG_FORMAT) != Attributes.end()
-            && Attributes[JSON_TAG_LINE_LOG_FORMAT] != nullptr)
+        if (Attributes.find(JSON_TAG_CUSTOM_LOG_FORMAT) != Attributes.end()
+            && Attributes[JSON_TAG_CUSTOM_LOG_FORMAT] != nullptr)
         {
-            NewSource.LineLogFormat = *(std::wstring*)Attributes[JSON_TAG_LINE_LOG_FORMAT];
+            NewSource.CustomLogFormat = *(std::wstring*)Attributes[JSON_TAG_CUSTOM_LOG_FORMAT];
         }
 
         return true;
@@ -385,7 +385,7 @@ class SourceETW : LogSource
 public:
     std::vector<ETWProvider> Providers;
     bool EventFormatMultiLine = true;
-    std::wstring LineLogFormat = L"[%TimeStamp%] [%Source%] [%Severity%] [%ProviderId%] [%ProviderName%] [%EventId%] %EventData%";
+    std::wstring CustomLogFormat = L"[%TimeStamp%] [%Source%] [%Severity%] [%ProviderId%] [%ProviderName%] [%EventId%] %EventData%";
 
     static bool Unwrap(
         _In_ AttributesMap& Attributes,
@@ -419,10 +419,10 @@ public:
         //
         // lineLogFormat is an optional value
         //
-        if (Attributes.find(JSON_TAG_LINE_LOG_FORMAT) != Attributes.end()
-            && Attributes[JSON_TAG_LINE_LOG_FORMAT] != nullptr)
+        if (Attributes.find(JSON_TAG_CUSTOM_LOG_FORMAT) != Attributes.end()
+            && Attributes[JSON_TAG_CUSTOM_LOG_FORMAT] != nullptr)
         {
-            NewSource.LineLogFormat = *(std::wstring*)Attributes[JSON_TAG_LINE_LOG_FORMAT];
+            NewSource.CustomLogFormat = *(std::wstring*)Attributes[JSON_TAG_CUSTOM_LOG_FORMAT];
         }
 
 

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -327,16 +327,19 @@ bool Utility::CompareWStrings(wstring stringA, wstring stringB)
         );
 }
 
-std::wstring Utility::FormatEventLineLog(_In_ std::wstring logLineFormat, _In_ void* pLogEntry, _In_ std::wstring sourceType)
+std::wstring Utility::FormatEventLineLog(_In_ std::wstring customLogFormat, _In_ void* pLogEntry, _In_ std::wstring sourceType)
 {
     size_t i = 0, j = 1;
-    while (i < logLineFormat.size()) {
-        auto sub = logLineFormat.substr(i, j);
+    while (i < customLogFormat.size()) {
+
+        auto sub = customLogFormat.substr(i, j - i);
         auto sub_length = sub.size();
+
         if (sub[0] != '%' && sub[sub_length - 1] != '%') {
             j++, i++;
         } else if (sub[0] == '%' && sub[sub_length - 1] == '%' && sub_length != 1) {
-            //valid field name found
+
+            //valid field name found in custom log format
             wstring fieldValue;
             if (sourceType == L"ETW") {
                 fieldValue = EtwMonitor::EtwFieldsMapping(sub.substr(1, sub_length - 2), pLogEntry);
@@ -348,13 +351,13 @@ std::wstring Utility::FormatEventLineLog(_In_ std::wstring logLineFormat, _In_ v
                 fieldValue = LogFileMonitor::FileFieldsMapping(sub.substr(1, sub_length - 2), pLogEntry);
             }
             //substitute the field name with value
-            logLineFormat.replace(i, j, fieldValue);
+            customLogFormat.replace(i, sub_length, fieldValue);
 
-            i = i + fieldValue.length(), j = 1;
+            i = i + fieldValue.length(), j = i + 1;
         } else {
             j++;
         }
     }
 
-    return logLineFormat;
+    return customLogFormat;
 }

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -325,3 +325,33 @@ bool Utility::CompareWStrings(wstring stringA, wstring stringB)
             }
         );
 }
+
+std::wstring Utility::SanitizeLineLogFormat(_In_ std::wstring str)
+{
+    //std::set<wstring> fields;
+    size_t i = 0, j = 1, ind = 0;
+    while (i < str.size()) {
+        auto sub = str.substr(i, j);
+        auto sub_length = sub.size();
+        if (sub[0] != '%' && sub[sub_length - 1] != '%') {
+            j++, i++;
+        }
+        else if (sub[0] == '%' && sub[sub_length - 1] == '%') {
+
+            //substring found
+            //fields.insert((sub.substr(1, sub_length - 2)));
+            wstring neString = L"+\"" + sub.substr(1, sub_length - 2) + L"+\"";
+            str.replace(i, j, neString);
+            //str.replace(i, j, L"%s");
+
+            i = i + neString.length(), j = 1;
+        }
+        else {
+            j++;
+        }
+    }
+
+    std::wstring formattedEvent = str;// Utility::FormatString(str.c_str(), "", "", "");
+
+    return formattedEvent;
+}

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -338,7 +338,6 @@ std::wstring Utility::FormatEventLineLog(_In_ std::wstring customLogFormat, _In_
         if (sub[0] != '%' && sub[sub_length - 1] != '%') {
             j++, i++;
         } else if (sub[0] == '%' && sub[sub_length - 1] == '%' && sub_length != 1) {
-
             //valid field name found in custom log format
             wstring fieldValue;
             if (sourceType == L"ETW") {

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -325,33 +325,3 @@ bool Utility::CompareWStrings(wstring stringA, wstring stringB)
             }
         );
 }
-
-std::wstring Utility::SanitizeLineLogFormat(_In_ std::wstring str)
-{
-    //std::set<wstring> fields;
-    size_t i = 0, j = 1, ind = 0;
-    while (i < str.size()) {
-        auto sub = str.substr(i, j);
-        auto sub_length = sub.size();
-        if (sub[0] != '%' && sub[sub_length - 1] != '%') {
-            j++, i++;
-        }
-        else if (sub[0] == '%' && sub[sub_length - 1] == '%') {
-
-            //substring found
-            //fields.insert((sub.substr(1, sub_length - 2)));
-            wstring neString = L"+\"" + sub.substr(1, sub_length - 2) + L"+\"";
-            str.replace(i, j, neString);
-            //str.replace(i, j, L"%s");
-
-            i = i + neString.length(), j = 1;
-        }
-        else {
-            j++;
-        }
-    }
-
-    std::wstring formattedEvent = str;// Utility::FormatString(str.c_str(), "", "", "");
-
-    return formattedEvent;
-}

--- a/LogMonitor/src/LogMonitor/Utility.h
+++ b/LogMonitor/src/LogMonitor/Utility.h
@@ -53,8 +53,4 @@ public:
         _In_ std::wstring stringA,
         _In_ std::wstring stringB
     );
-
-    static std::wstring SanitizeLineLogFormat(
-        _In_ std::wstring str
-    );
 };

--- a/LogMonitor/src/LogMonitor/Utility.h
+++ b/LogMonitor/src/LogMonitor/Utility.h
@@ -53,4 +53,8 @@ public:
         _In_ std::wstring stringA,
         _In_ std::wstring stringB
     );
+
+    static std::wstring SanitizeLineLogFormat(
+        _In_ std::wstring str
+    );
 };

--- a/LogMonitor/src/LogMonitor/Utility.h
+++ b/LogMonitor/src/LogMonitor/Utility.h
@@ -54,5 +54,5 @@ public:
         _In_ std::wstring stringB
     );
 
-    std::wstring FormatEventLineLog(_In_ std::wstring customLogFormat, _In_ void* pLogEntry, _In_ std::wstring sourceType);
+    static std::wstring FormatEventLineLog(_In_ std::wstring customLogFormat, _In_ void* pLogEntry, _In_ std::wstring sourceType);
 };

--- a/LogMonitor/src/LogMonitor/Utility.h
+++ b/LogMonitor/src/LogMonitor/Utility.h
@@ -53,4 +53,6 @@ public:
         _In_ std::wstring stringA,
         _In_ std::wstring stringB
     );
+
+    std::wstring FormatEventLineLog(_In_ std::wstring logLineFormat, _In_ void* pLogEntry, _In_ std::wstring sourceType);
 };

--- a/LogMonitor/src/LogMonitor/Utility.h
+++ b/LogMonitor/src/LogMonitor/Utility.h
@@ -54,5 +54,5 @@ public:
         _In_ std::wstring stringB
     );
 
-    std::wstring FormatEventLineLog(_In_ std::wstring logLineFormat, _In_ void* pLogEntry, _In_ std::wstring sourceType);
+    std::wstring FormatEventLineLog(_In_ std::wstring customLogFormat, _In_ void* pLogEntry, _In_ std::wstring sourceType);
 };


### PR DESCRIPTION
**Summary**

In addition to getting logs in XML and JSON formats, a user should have the flexibility to customize their windows container logs, dictating how the logs should look like and the specific fields that should appear in log entries.  

For Example: 
To display the timestamp, source, severity and message of an event in STDOUT, a user can specify the following format: 
`[%TimeStamp%] [%Source%] [%Severity%] %Message% `



**Examples:**

**1. Event Logs**
**Configuration:** `"customLogFormat": "[%TimeStamp%] [%Source%] [%Severity%] %Message%"` 
**Output:** _
```
[2023-02-17T02:35:42.000Z] [EventLog] [Information] Successfully logged OS information
```

**2. ETW Logs**
**Configuration:** ` "customLogFormat": "[%TimeStamp%] [%Source%] [%Severity%] [%ProviderId%] [%ProviderName%] [%EventId%] %EventData%"`
**Output:** _
```
[2023-03-10T07:27:59.000Z] [ETW] [Information] [{DAA6A96B-F3E7-4D4D-A0D6-31A350E6A445}] [Microsoft-Windows-WLAN-Driver] [1] FrameUniqueID: 462621 QueueLength: 0 QueueState: false Status: 0 CustomData1: 0 CustomData2: 0 CustomData3: 0
```

**3. File Logs**
**Configuration:** `"[%TimeStamp%] [%Source%] [%FileName%] %Message%"`
**Output:** 
```
[2023-03-10T07:31:08.000Z] [File] [Trial.log] Testing file log entry on STDOUT
```

**Sample Config used in testing:**
```json
{
  "LogConfig": {
    "logFormat": "custom",
    "sources": [
      {
        "type": "File",
        "directory": "c:\\inetpub\\logs",
        "filter": "*.log",
        "includeSubdirectories": true,
        "customLogFormat": "[%TimeStamp%] [%Source%] [%FileName%] %Message%"
      },
      {
        "type": "ETW",
        "eventFormatMultiLine": false,
        "providers": [
          {
            "providerName": "Microsoft-Windows-WLAN-Drive",
            "providerGuid": "DAA6A96B-F3E7-4D4D-A0D6-31A350E6A445",
            "level": "Information"
          }
        ],
        "customLogFormat": "[%TimeStamp%] [%Source%] [%Severity%] [%ProviderId%] [%ProviderName%] [%DecodingSource%] [%ExecutionProcessId%] [%ExecutionThreadId%] [%EventId%] %eventdata%"
      }
    ]
  }
}
```