### PR TITLE
Custom JSON Log Sanitization

### DIFF
--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -579,6 +579,7 @@ EventMonitor::PrintEvent(
                         // sanitize message
                         std::wstring msg(m_eventMessageBuffer.begin(), m_eventMessageBuffer.end());
                         Utility::SanitizeJson(msg);
+                        pLogEntry->eventMessage = msg;
                     }
 
                     formattedEvent = Utility::FormatString(

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1724,6 +1724,7 @@ void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstrin
                     logFmt = L"{\"Source\": \"File\",\"LogEntry\": {\"Logline\": \"%s\",\"FileName\": \"%s\"},\"SchemaVersion\":\"1.0.0\"}";
                     // sanitize message
                     Utility::SanitizeJson(msg);
+                    pLogEntry->message = msg;
                 }
 
                 formattedFileEntry = Utility::FormatString(

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -373,6 +373,7 @@ void Utility::SanitizeCustomLog(_Inout_ std::wstring& customLog)
 
     if (!substr.empty() && CompareWStrings(substr, L"JSON"))
         SanitizeJson(customLog);
+        customLog = ReplaceAll(customLog, L"'", L"\"");
 
     customLog = customLog.substr(0, customLog.find(L"|"));
 }

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -366,8 +366,8 @@ std::wstring Utility::FormatEventLineLog(_In_ std::wstring customLogFormat, _In_
 void Utility::SanitizeCustomLog(_Inout_ std::wstring& customLog)
 {
     auto npos = customLog.find(L"|");
-
     std::wstring substr;
+
     if (npos != std::string::npos)
         substr = customLog.substr(npos + 1);
 

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -268,6 +268,7 @@ void Utility::SanitizeJson(_Inout_ std::wstring& str)
     size_t i = 0;
     while (i < str.size()) {
         auto sub = str.substr(i, 1);
+        auto s = str.substr(0, i + 1);
         if (sub == L"\"") {
             if ((i > 0 && str.substr(i - 1, 1) != L"\\" && str.substr(i - 1, 1) != L"~")
                 || i == 0)
@@ -277,7 +278,7 @@ void Utility::SanitizeJson(_Inout_ std::wstring& str)
             }
             else if (i > 0 && str.substr(i - 1, 1) == L"~") {
                 str.replace(i - 1, 1, L"");
-                i++;
+                i--;
             }
         }
         else if (sub == L"\\") {

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -358,5 +358,21 @@ std::wstring Utility::FormatEventLineLog(_In_ std::wstring customLogFormat, _In_
         }
     }
 
+    SanitizeCustomLog(customLogFormat);
+
     return customLogFormat;
+}
+
+void Utility::SanitizeCustomLog(_Inout_ std::wstring& customLog)
+{
+    auto npos = customLog.find(L"|");
+
+    std::wstring substr;
+    if (npos != std::string::npos)
+        substr = customLog.substr(npos + 1);
+
+    if (!substr.empty() && CompareWStrings(substr, L"JSON"))
+        SanitizeJson(customLog);
+
+    customLog = customLog.substr(0, customLog.find(L"|"));
 }

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -269,10 +269,14 @@ void Utility::SanitizeJson(_Inout_ std::wstring& str)
     while (i < str.size()) {
         auto sub = str.substr(i, 1);
         if (sub == L"\"") {
-            if ((i > 0 && str.substr(i - 1, 1) != L"\\")
+            if ((i > 0 && str.substr(i - 1, 1) != L"\\" && str.substr(i - 1, 1) != L"~")
                 || i == 0)
             {
                 str.replace(i, 1, L"\\\"");
+                i++;
+            }
+            else if (i > 0 && str.substr(i - 1, 1) == L"~") {
+                str.replace(i - 1, 1, L"");
                 i++;
             }
         }
@@ -329,6 +333,8 @@ bool Utility::CompareWStrings(wstring stringA, wstring stringB)
 
 std::wstring Utility::FormatEventLineLog(_In_ std::wstring customLogFormat, _In_ void* pLogEntry, _In_ std::wstring sourceType)
 {
+    bool customJsonFormat = isCustomJsonFormat(customLogFormat);
+
     size_t i = 0, j = 1;
     while (i < customLogFormat.size()) {
 
@@ -358,22 +364,33 @@ std::wstring Utility::FormatEventLineLog(_In_ std::wstring customLogFormat, _In_
         }
     }
 
-    SanitizeCustomLog(customLogFormat);
+    if(customJsonFormat)
+        SanitizeJson(customLogFormat);
 
     return customLogFormat;
 }
-
-void Utility::SanitizeCustomLog(_Inout_ std::wstring& customLog)
+ 
+/// <summary>
+/// check if custom format specified in config is JSON for sanitization purposes
+/// </summary>
+/// <param name="customLogFormat"></param>
+/// <returns></returns>
+bool Utility::isCustomJsonFormat(_Inout_ std::wstring& customLogFormat)
 {
-    auto npos = customLog.find(L"|");
+    bool isCustomJSONFormat = false;
+
+    auto npos = customLogFormat.find_last_of(L"|");
     std::wstring substr;
-    if (npos != std::string::npos)
-        substr = customLog.substr(npos + 1);
+    if (npos != std::string::npos) {
+        substr = customLogFormat.substr(npos + 1);
         substr.erase(std::remove(substr.begin(), substr.end(), ' '), substr.end());
 
-    if (!substr.empty() && CompareWStrings(substr, L"JSON"))
-        SanitizeJson(customLog);
-        customLog = ReplaceAll(customLog, L"'", L"\"");
+        if (!substr.empty() && CompareWStrings(substr, L"JSON")) {
+            customLogFormat = ReplaceAll(customLogFormat, L"'", L"~\"");
+            isCustomJSONFormat = true;
+        }
 
-    customLog = customLog.substr(0, customLog.find(L"|"));
+        customLogFormat = customLogFormat.substr(0, customLogFormat.find_last_of(L"|"));
+    }
+    return isCustomJSONFormat;
 }

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -367,9 +367,9 @@ void Utility::SanitizeCustomLog(_Inout_ std::wstring& customLog)
 {
     auto npos = customLog.find(L"|");
     std::wstring substr;
-
     if (npos != std::string::npos)
         substr = customLog.substr(npos + 1);
+        substr.erase(std::remove(substr.begin(), substr.end(), ' '), substr.end());
 
     if (!substr.empty() && CompareWStrings(substr, L"JSON"))
         SanitizeJson(customLog);

--- a/LogMonitor/src/LogMonitor/Utility.h
+++ b/LogMonitor/src/LogMonitor/Utility.h
@@ -56,5 +56,5 @@ public:
 
     static std::wstring FormatEventLineLog(_In_ std::wstring customLogFormat, _In_ void* pLogEntry, _In_ std::wstring sourceType);
 
-    static void SanitizeCustomLog(_Inout_ std::wstring& customLog);
+    static bool isCustomJsonFormat(_Inout_ std::wstring& customLogFormat);
 };

--- a/LogMonitor/src/LogMonitor/Utility.h
+++ b/LogMonitor/src/LogMonitor/Utility.h
@@ -55,4 +55,6 @@ public:
     );
 
     static std::wstring FormatEventLineLog(_In_ std::wstring customLogFormat, _In_ void* pLogEntry, _In_ std::wstring sourceType);
+
+    static void SanitizeCustomLog(_Inout_ std::wstring& customLog);
 };


### PR DESCRIPTION
**Task: Sanitize custom JSON Logs**

For users who might want to specify their own custom JSON log format, they can do so by:

1. Specifying the logFormat as 'custom' 
2. Adding '|json' suffix after the desired custom log format. This is to specify the sanitization method, to aid in validating the log outputs.

Sample configuration:
```
{
  "LogConfig": {
	"logFormat": "custom",
        "sources": [
	      {
                "type": "ETW",
                "eventFormatMultiLine": false,
                "providers": [
                  {
                     "providerName": "Microsoft-Windows-WLAN-Drive",
                    "providerGuid": "DAA6A96B-F3E7-4D4D-A0D6-31A350E6A445",
                    "level": "Information"
                   }
                 ],
                "customLogFormat": "{'TimeStamp':'%TimeStamp%', 'source':'%Source%', 'Severity':'%Severity%', 'ProviderId':'%ProviderId%', 'ProviderName':'%ProviderName%', 'EventId':'%EventId%', 'Message':'%Message%'}|json"
	      }
        ]
  }
}
```