### PR TITLE
fix: update component governance step in build pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,9 +24,9 @@ jobs:
 
     - task: ComponentGovernanceComponentDetection@0
       inputs:
-        scanType: 'LogOnly'
+        scanType: 'Register'
         verbosity: 'Verbose'
-        alertWarningLevel: 'High'
+        alertWarningLevel: 'Low'
 
     - task: VisualStudioTestPlatformInstaller@1
       inputs:


### PR DESCRIPTION
**Tasks:**
Amend the pipeline's Component Governance task to Register OSS vulnerabilities for alerting and work items creation purposes Change the minimum alert severity to warn as 'Low'. (all vulnerabilities equal or greater than Low will be registered, however, alerting level can be configured differently)



**Testing:**
Component Governance page view before running pipeline changes:
![image](https://user-images.githubusercontent.com/28774968/234032279-4a3e1612-0ac2-4564-84a2-c70ecc376ee7.png)


Component Governance page view after running pipeline changes:
![image](https://user-images.githubusercontent.com/28774968/234029042-c4c363f7-5954-419e-bc74-6bee465ec080.png)


![image](https://user-images.githubusercontent.com/28774968/234029220-e2e518c1-eb37-41af-ac98-6539b207839c.png)
