### PR TITLE
Identify the ProviderGuid failing with 1168

### DIFF
--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -694,7 +694,6 @@ EtwMonitor::OnRecordEvent(
             logWriter.TraceError(
                 Utility::FormatString(L"Failed to query ETW event information for ProviderGUID: %s Error: %lu",
                 guidString, status).c_str());
-
         }
 
 

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -679,32 +679,30 @@ EtwMonitor::OnRecordEvent(
         if (ERROR_SUCCESS != status)
         {
             // Handle 1168 fails in this block
-            if (ERROR_NOT_FOUND == status)          
+            if (ERROR_NOT_FOUND == status)
             {
                 // Access the ProviderId from the EVENT_HEADER field
                 GUID providerId = EventRecord->EventHeader.ProviderId;
-                
+
                 LPOLESTR clsidString;
                 if (StringFromCLSID(providerId, &clsidString) != S_OK)
                 {
                     logWriter.TraceError(
-                        Utility::FormatString(L"Failed to allocate necessary memory Error: %lu",E_OUTOFMEMORY).c_str()
-                    );
+                        Utility::FormatString(L"Failed to allocate necessary memory Error: %lu",
+                        E_OUTOFMEMORY).c_str());
                 }
-                
+
                 std::wstring guidString(clsidString);
                 CoTaskMemFree(clsidString);
-                
+
                 logWriter.TraceError(
-                    Utility::FormatString(L"Failed to query ETW event information for ProviderGUID: %s Error: %lu", guidString, status).c_str()
-                );
+                    Utility::FormatString(L"Failed to query ETW event information for ProviderGUID: %s Error: %lu",
+                    guidString, status).c_str());
             }
-            
+
             // Handle all non 1168 fails here
             logWriter.TraceError(
-                Utility::FormatString(L"Failed to query ETW event information. Error: %lu", status).c_str()
-            );
-            
+                Utility::FormatString(L"Failed to query ETW event information. Error: %lu", status).c_str());
         }
 
 

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -678,31 +678,23 @@ EtwMonitor::OnRecordEvent(
 
         if (ERROR_SUCCESS != status)
         {
-            // Handle 1168 fails in this block
-            if (ERROR_NOT_FOUND == status)
+            GUID providerId = EventRecord->EventHeader.ProviderId;
+
+            LPOLESTR clsidString;
+            if (StringFromCLSID(providerId, &clsidString) != S_OK)
             {
-                // Access the ProviderId from the EVENT_HEADER field
-                GUID providerId = EventRecord->EventHeader.ProviderId;
-
-                LPOLESTR clsidString;
-                if (StringFromCLSID(providerId, &clsidString) != S_OK)
-                {
-                    logWriter.TraceError(
-                        Utility::FormatString(L"Failed to allocate necessary memory Error: %lu",
-                        E_OUTOFMEMORY).c_str());
-                }
-
-                std::wstring guidString(clsidString);
-                CoTaskMemFree(clsidString);
-
                 logWriter.TraceError(
-                    Utility::FormatString(L"Failed to query ETW event information for ProviderGUID: %s Error: %lu",
-                    guidString, status).c_str());
+                    Utility::FormatString(L"Failed to convert GUID to string, ran out of memory Error: %lu",
+                    E_OUTOFMEMORY).c_str());
             }
 
-            // Handle all non 1168 fails here
+            std::wstring guidString(clsidString);
+            CoTaskMemFree(clsidString);
+
             logWriter.TraceError(
-                Utility::FormatString(L"Failed to query ETW event information. Error: %lu", status).c_str());
+                Utility::FormatString(L"Failed to query ETW event information for ProviderGUID: %s Error: %lu",
+                guidString, status).c_str());
+
         }
 
 

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -678,24 +678,33 @@ EtwMonitor::OnRecordEvent(
 
         if (ERROR_SUCCESS != status)
         {
-            // Access the ProviderId from the EVENT_HEADER field
-            GUID providerId = EventRecord->EventHeader.ProviderId;
-
-            LPOLESTR clsidString;
-            if (StringFromCLSID(providerId, &clsidString) != S_OK)
+            // Handle 1168 fails in this block
+            if (ERROR_NOT_FOUND == status)          
             {
+                // Access the ProviderId from the EVENT_HEADER field
+                GUID providerId = EventRecord->EventHeader.ProviderId;
+                
+                LPOLESTR clsidString;
+                if (StringFromCLSID(providerId, &clsidString) != S_OK)
+                {
+                    logWriter.TraceError(
+                        Utility::FormatString(L"Failed to allocate necessary memory Error: %lu",E_OUTOFMEMORY).c_str()
+                    );
+                }
+                
+                std::wstring guidString(clsidString);
+                CoTaskMemFree(clsidString);
+                
                 logWriter.TraceError(
-                    Utility::FormatString(L"Failed to convert GUID to string").c_str()
+                    Utility::FormatString(L"Failed to query ETW event information for ProviderGUID: %s Error: %lu", guidString, status).c_str()
                 );
             }
-
-            std::wstring guidString(clsidString);
-            CoTaskMemFree(clsidString);
-
-
+            
+            // Handle all non 1168 fails here
             logWriter.TraceError(
-                Utility::FormatString(L"Failed to query ETW event information for ProviderGUID: %s Error: %lu", guidString, status).c_str()
+                Utility::FormatString(L"Failed to query ETW event information. Error: %lu", status).c_str()
             );
+            
         }
 
 

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -678,8 +678,23 @@ EtwMonitor::OnRecordEvent(
 
         if (ERROR_SUCCESS != status)
         {
+            // Access the ProviderId from the EVENT_HEADER field
+            GUID providerId = EventRecord->EventHeader.ProviderId;
+
+            LPOLESTR clsidString;
+            if (StringFromCLSID(providerId, &clsidString) != S_OK)
+            {
+                logWriter.TraceError(
+                    Utility::FormatString(L"Failed to convert GUID to string").c_str()
+                );
+            }
+
+            std::wstring guidString(clsidString);
+            CoTaskMemFree(clsidString);
+
+
             logWriter.TraceError(
-                Utility::FormatString(L"Failed to query ETW event information. Error: %lu", status).c_str()
+                Utility::FormatString(L"Failed to query ETW event information for ProviderGUID: %s Error: %lu", guidString, status).c_str()
             );
         }
 


### PR DESCRIPTION
This change it to help us figure out ETW events failing with 1168: ERROR_NOT_FOUND code.

We do not have a fix at the moment. 

This change is to do the following:

1. Help us identify the ProviderGuid failing with 1168 code
2. Give an informative error message 
3. Help us identify more ETW Providers having this specific failure
