### PR TITLE
Add waitInSeconds field to retry if folder/file does not exist

### DIFF
--- a/LogMonitor/LogMonitorTests/LogFileMonitorTests.cpp
+++ b/LogMonitor/LogMonitorTests/LogFileMonitorTests.cpp
@@ -176,7 +176,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.WaitInSeconds);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -224,7 +224,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.WaitInSeconds);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -241,7 +241,7 @@ namespace LogMonitorTests
             // Check that LogFileMonitor started successfully.
             //
             output = RecoverOuput();
-            Assert::AreEqual(L"", output.c_str());
+            Assert::IsTrue(output.find(L"INFO") != std::wstring::npos);
             {
                 std::wstring filename = sourceFile.Directory + L"\\testfile.txt";
                 std::string content = "Hello World!";
@@ -288,11 +288,12 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
+            sourceFile.WaitInSeconds = 10;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.WaitInSeconds);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -395,7 +396,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.WaitInSeconds);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -566,11 +567,12 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
+            sourceFile.WaitInSeconds = 10;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.WaitInSeconds);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -671,11 +673,12 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
+            sourceFile.WaitInSeconds = 10;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.WaitInSeconds);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -790,11 +793,12 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
+            sourceFile.WaitInSeconds = 10;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.WaitInSeconds);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -980,11 +984,12 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
+            sourceFile.WaitInSeconds = 10;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.WaitInSeconds);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //

--- a/LogMonitor/docs/README.md
+++ b/LogMonitor/docs/README.md
@@ -217,7 +217,42 @@ This will monitor any changes in log files matching a specified filter, given th
 - `filter` (optional): uses [MS-DOS wildcard match type](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/indexsrv/ms-dos-and-windows-wildcard-characters) i.e.. `*, ?`. Can be set to empty, which will be default to `"*"`.
 - `includeSubdirectories` (optional) : `"true|false"`, specify if sub-directories also need to be monitored. Defaults to `false`.
 - `includeFileNames` (optional): `"true|false"`, specifies whether to include file names in the logline, eg. `sample.log: xxxxx`. Defaults to `false`.
+- `waitInSeconds` (optional): specifies the duration to wait for a file or folder to be created if it does not exist. It takes integer values between 0-INFINITY. Defaults to `300` seconds, i.e, 5 minutes. It can be passed as a value or a string. 
 
+  -	`waitInSeconds = 0`
+
+    When the value is zero(0), this is means that we do not wait and LogMonitor terminates with an error
+
+  -	`waitInSeconds = +integer`
+        
+    When the value is a positive integer, LogMonitor will wait for the specified time. Once the predefined time elapses, LogMonitor will terminate with an error.
+
+  -	`waitInSeconds = "INFINITY"`
+
+    In this case, LogMonitor will wait forever for the folder to be created. 
+      
+    **NOTE:**
+    - This field is case insensitive
+    - When "INFINITY" is passed, it must be passed as a string.
+    - The infinity symbol, ∞, is also allowed as a string or the symbol itself.
+
+  <br />
+
+  **Examples:**
+  1. Wait for 10 seconds
+      * As a value: `"waitInSeconds": 10`
+      * As a string: `"waitInSeconds": "10"` 
+  2. Wait forever/infinitely:
+      * `"waitInSeconds": "INFINITY"` or  `"waitInSeconds": "inf"` or  `"waitInSeconds": "∞"`
+      * This field is case-insensitive
+
+  <br />
+
+  If a user provides an invalid value, a value less than 0, an error occurs:
+  ```
+  ERROR: Error parsing configuration file. 'waitInSeconds' attribute must be greater or equal to zero
+  WARNING: Failed to parse configuration file. Error retrieving source attributes. Invalid source
+  ```
 
 ### Examples
 
@@ -230,7 +265,8 @@ This will monitor any changes in log files matching a specified filter, given th
         "directory": "c:\\inetpub\\logs",
         "filter": "*.log",
         "includeSubdirectories": true,
-        "includeFileNames": false
+        "includeFileNames": false,
+        "waitInSeconds": 10
       }
     ]
   }

--- a/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
+++ b/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
@@ -363,6 +363,29 @@ ReadSourceAttributes(
                     Attributes[key] = providers;
                 }
             }
+            else if (_wcsnicmp(key.c_str(), JSON_TAG_WAITINSECONDS, _countof(JSON_TAG_WAITINSECONDS)) == 0)
+            {
+                try
+                {
+                    auto parsedValue = new std::double_t(Parser.ParseNumericValue());
+                    if (*parsedValue < 0)
+                    {
+                        logWriter.TraceError(L"Error parsing configuration file. 'waitInSeconds' attribute must be greater or equal to zero");
+                        success = false;
+                    }
+                    else
+                    {
+                        Attributes[key] = parsedValue;
+                    }
+                }
+                catch(const std::exception& ex)
+                {
+                    logWriter.TraceError(
+                        Utility::FormatString(L"Error parsing configuration file atrribute 'waitInSeconds'. %S", ex.what()).c_str()
+                    );
+                    success = false;
+                }
+            }
             else
             {
                 //
@@ -656,6 +679,7 @@ void _PrintSettings(_Out_ LoggerSettings& Config)
             std::wprintf(L"\t\tDirectory: %ls\n", sourceFile->Directory.c_str());
             std::wprintf(L"\t\tFilter: %ls\n", sourceFile->Filter.c_str());
             std::wprintf(L"\t\tIncludeSubdirectories: %ls\n", sourceFile->IncludeSubdirectories ? L"true" : L"false");
+            std::wprintf(L"\t\twaitInSeconds: %d\n", int(sourceFile->WaitInSeconds));
             std::wprintf(L"\n");
 
             break;

--- a/LogMonitor/src/LogMonitor/FileMonitor/Utilities.cpp
+++ b/LogMonitor/src/LogMonitor/FileMonitor/Utilities.cpp
@@ -35,9 +35,8 @@ HANDLE CreateFileMonitorEvent(
  * 
  * @return HANDLE 
  */
-HANDLE GetLogDirHandle(std::wstring logDirectory, HANDLE stopEvent) {
+HANDLE GetLogDirHandle(_In_ std::wstring logDirectory, _In_ HANDLE stopEvent, _In_ std::double_t waitInSeconds) {
     DWORD status = ERROR_SUCCESS;
-    const int eventsCount = 2;
 
     HANDLE logDirHandle = CreateFileW (logDirectory.c_str(),
                                  FILE_LIST_DIRECTORY,
@@ -55,18 +54,15 @@ HANDLE GetLogDirHandle(std::wstring logDirectory, HANDLE stopEvent) {
     if (status == ERROR_FILE_NOT_FOUND ||
         status == ERROR_PATH_NOT_FOUND)
     {
+        std::wstring waitLogMesage = _GetWaitLogMessage(logDirectory, waitInSeconds);
+        logWriter.TraceInfo(waitLogMesage.c_str());
+
         //
         // Log directory is not created yet. Keep retrying every
         // 15 seconds for upto five minutes. Also start reading the
         // log files from the begining, instead of current end of
         // file.
         //
-        const DWORD maxRetryCount = 20;
-        DWORD retryCount = 1;
-        LARGE_INTEGER liDueTime;
-        INT64 millisecondsToWait = 15000LL;
-        liDueTime.QuadPart = -millisecondsToWait*10000LL; // wait time in 100 nanoseconds
-
         HANDLE timerEvent = CreateWaitableTimer(NULL, FALSE, NULL);
         if (!timerEvent)
         {
@@ -81,82 +77,154 @@ HANDLE GetLogDirHandle(std::wstring logDirectory, HANDLE stopEvent) {
             return INVALID_HANDLE_VALUE;
         }
 
-        HANDLE dirOpenEvents[eventsCount] = {stopEvent, timerEvent};
-
-        while (status == ERROR_FILE_NOT_FOUND &&
-                retryCount < maxRetryCount)
-        {
-            if (!SetWaitableTimer(timerEvent, &liDueTime, 0, NULL, NULL, 0))
-            {
-                status = GetLastError();
-                logWriter.TraceError(
-                    Utility::FormatString(
-                        L"Failed to set timer object to monitor log file changes in directory %s. Error: %lu",
-                        logDirectory.c_str(),
-                        status
-                    ).c_str()
-                );
-                break;
-            }
-
-            DWORD wait = WaitForMultipleObjects(eventsCount, dirOpenEvents, FALSE, INFINITE);
-            switch(wait)
-            {
-                case WAIT_OBJECT_0:
-                {
-                    //
-                    // The process is exiting. Stop the timer and return.
-                    //
-                    CancelWaitableTimer(timerEvent);
-                    CloseHandle(timerEvent);
-                    return INVALID_HANDLE_VALUE;
-                }
-
-                case WAIT_OBJECT_0 + 1:
-                {
-                    //
-                    // Timer event. Retry opening directory handle.
-                    //
-                    break;
-                }
-
-                default:
-                {
-                    //
-                    //Wait failed, return the failure.
-                    //
-                    status = GetLastError();
-
-                    CancelWaitableTimer(timerEvent);
-                    CloseHandle(timerEvent);
-
-                    return INVALID_HANDLE_VALUE;
-                }
-            }
-
-            logDirHandle = CreateFileW (logDirectory.c_str(),
-                                          FILE_LIST_DIRECTORY,
-                                          FILE_SHARE_READ | FILE_SHARE_WRITE,
-                                          nullptr,
-                                          OPEN_EXISTING,
-                                          FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
-                                          nullptr);
-
-            if (logDirHandle == INVALID_HANDLE_VALUE)
-            {
-                status = GetLastError();
-                ++retryCount;
-            }
-            else
-            {
-                status = ERROR_SUCCESS;
-                break;
-            }
-        }
+        logDirHandle = _RetryOpenDirectoryWithInterval(logDirectory, waitInSeconds, stopEvent, timerEvent);
 
         CancelWaitableTimer(timerEvent);
         CloseHandle(timerEvent);
     }
 
     return logDirHandle;
+}
+
+HANDLE _RetryOpenDirectoryWithInterval(
+    std::wstring logDirectory,
+    std::double_t waitInSeconds,
+    HANDLE stopEvent,
+    HANDLE timerEvent)
+{
+    HANDLE logDirHandle = INVALID_HANDLE_VALUE;
+    DWORD status = ERROR_FILE_NOT_FOUND;
+    int elapsedTime = 0;
+
+    const int eventsCount = 2;
+    HANDLE dirOpenEvents[eventsCount] = {stopEvent, timerEvent};
+
+    while (_IsFileErrorStatus(status) && elapsedTime < waitInSeconds)
+    {
+        int waitInterval = _GetWaitInterval(waitInSeconds, elapsedTime);
+        LARGE_INTEGER timeToWait = _ConvertWaitIntervalToLargeInt(waitInterval);
+
+        BOOL waitableTimer = SetWaitableTimer(timerEvent, &timeToWait, 0, NULL, NULL, 0);
+        if (!waitableTimer)
+        {
+            status = GetLastError();
+            logWriter.TraceError(
+                Utility::FormatString(
+                    L"Failed to set timer object to monitor log file changes in directory %s. Error: %lu",
+                    logDirectory.c_str(),
+                    status)
+                    .c_str());
+            break;
+        }
+
+        DWORD wait = WaitForMultipleObjects(eventsCount, dirOpenEvents, FALSE, INFINITE);
+        switch (wait)
+        {
+        case WAIT_OBJECT_0:
+        {
+            //
+            // The process is exiting. Stop the timer and return.
+            //
+            CancelWaitableTimer(timerEvent);
+            CloseHandle(timerEvent);
+            return INVALID_HANDLE_VALUE;
+        }
+
+        case WAIT_OBJECT_0 + 1:
+        {
+            //
+            // Timer event. Retry opening directory handle.
+            //
+            break;
+        }
+
+        default:
+        {
+            //
+            // Wait failed, return the failure.
+            //
+            status = GetLastError();
+
+            CancelWaitableTimer(timerEvent);
+            CloseHandle(timerEvent);
+
+            return INVALID_HANDLE_VALUE;
+        }
+        }
+
+        logDirHandle = CreateFileW(
+            logDirectory.c_str(),
+            FILE_LIST_DIRECTORY,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            nullptr,
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
+            nullptr);
+
+        if (logDirHandle == INVALID_HANDLE_VALUE)
+        {
+            status = GetLastError();
+            elapsedTime += WAIT_INTERVAL;
+        }
+        else
+        {
+            logWriter.TraceInfo(
+                Utility::FormatString(
+                    L"Log directory %ws found after %d seconds.", logDirectory.c_str(), elapsedTime)
+                    .c_str());
+            status = ERROR_SUCCESS;
+            break;
+        }
+    }
+
+    return logDirHandle;
+}
+
+// Converts the time to wait to a large integer
+LARGE_INTEGER _ConvertWaitIntervalToLargeInt(int timeInterval)
+{
+    LARGE_INTEGER liDueTime{};
+
+    int millisecondsToWait = timeInterval * 1000;
+    liDueTime.QuadPart = -millisecondsToWait * 10000LL; // wait time in 100 nanoseconds
+    return liDueTime;
+}
+
+// Returns the time (in seconds) to wait based on the specified waitInSeconds
+int _GetWaitInterval(std::double_t waitInSeconds, int elapsedTime)
+{
+    if (isinf(waitInSeconds))
+    {
+        return int(WAIT_INTERVAL);
+    }
+
+    if (waitInSeconds < WAIT_INTERVAL)
+    {
+        return int(waitInSeconds);
+    }
+
+    const auto remainingTime = int(waitInSeconds - elapsedTime);
+    return remainingTime <= WAIT_INTERVAL ? remainingTime : WAIT_INTERVAL;
+}
+
+bool _IsFileErrorStatus(DWORD status)
+{
+    return status == ERROR_FILE_NOT_FOUND || status == ERROR_PATH_NOT_FOUND;
+}
+
+std::wstring _GetWaitLogMessage(_In_ std::wstring logDirectory, _In_ std::double_t waitInSeconds)
+{
+    if (isinf(waitInSeconds))
+    {
+        return Utility::FormatString(
+            L"Log directory %ws does not exist. LogMonitor will wait infinitely for the directory to be created.",
+            logDirectory.c_str());
+    }
+    else
+    {
+        return Utility::FormatString(
+            L"Log directory %ws does not exist. LogMonitor will wait for %.0f seconds for the directory to be created.",
+            logDirectory.c_str(),
+            waitInSeconds);
+    }
 }

--- a/LogMonitor/src/LogMonitor/FileMonitor/Utilities.h
+++ b/LogMonitor/src/LogMonitor/FileMonitor/Utilities.h
@@ -5,10 +5,33 @@
 
 #pragma once
 
+const int WAIT_INTERVAL = 15;
+
 HANDLE CreateFileMonitorEvent(
     _In_ BOOL bManualReset,
     _In_ BOOL bInitialState);
 
 HANDLE GetLogDirHandle(
     _In_ std::wstring logDirectory,
-    _In_ HANDLE stopEvent);
+    _In_ HANDLE stopEvent,
+    _In_ std::double_t waitInSeconds);
+
+HANDLE _RetryOpenDirectoryWithInterval(
+    std::wstring logDirectory,
+    std::double_t waitInSeconds,
+    HANDLE stopEvent,
+    HANDLE timerEvent);
+
+LARGE_INTEGER _ConvertWaitIntervalToLargeInt(
+    int timeInterval);
+
+int _GetWaitInterval(
+    std::double_t waitInSeconds,
+    int elapsedTime);
+
+bool _IsFileErrorStatus(
+    DWORD status);
+
+std::wstring _GetWaitLogMessage(
+    _In_ std::wstring logDirectory,
+    _In_ std::double_t waitInSeconds);

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -39,11 +39,13 @@ using namespace std;
 ///
 LogFileMonitor::LogFileMonitor(_In_ const std::wstring& LogDirectory,
                                _In_ const std::wstring& Filter,
-                               _In_ bool IncludeSubfolders
+                               _In_ bool IncludeSubfolders,
+                               _In_ const std::double_t& WaitInSeconds
                                ) :
                                m_logDirectory(LogDirectory),
                                m_filter(Filter),
-                               m_includeSubfolders(IncludeSubfolders)
+                               m_includeSubfolders(IncludeSubfolders),
+                               m_waitInSeconds(WaitInSeconds)
 {
     m_stopEvent = NULL;
     m_overlappedEvent = NULL;
@@ -314,7 +316,7 @@ LogFileMonitor::StartLogFileMonitor()
     dirMonitorStartedEventSignalled = true;
 
     // Get Log Dir Handle
-    HANDLE logDirHandle = GetLogDirHandle(m_logDirectory, m_stopEvent);
+    HANDLE logDirHandle = GetLogDirHandle(m_logDirectory, m_stopEvent, m_waitInSeconds);
 
     if(logDirHandle == INVALID_HANDLE_VALUE) {
         status = GetLastError();

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.h
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.h
@@ -60,7 +60,8 @@ public:
     LogFileMonitor(
         _In_ const std::wstring& LogDirectory,
         _In_ const std::wstring& Filter,
-        _In_ bool IncludeSubfolders
+        _In_ bool IncludeSubfolders,
+        _In_ const std::double_t& WaitInSeconds
         );
 
     ~LogFileMonitor();
@@ -72,6 +73,7 @@ private:
     std::wstring m_logDirectory;
     std::wstring m_shortLogDirectory;
     std::wstring m_filter;
+    std::double_t m_waitInSeconds;
     bool m_includeSubfolders;
 
     //

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -112,7 +112,8 @@ void StartMonitors(_In_ LoggerSettings& settings)
                     std::shared_ptr<LogFileMonitor> logfileMon = make_shared<LogFileMonitor>(
                         sourceFile->Directory,
                         sourceFile->Filter,
-                        sourceFile->IncludeSubdirectories
+                        sourceFile->IncludeSubdirectories,
+                        sourceFile->WaitInSeconds
                     );
                     g_logfileMonitors.push_back(std::move(logfileMon));
                 }

--- a/LogMonitor/src/LogMonitor/Parser/JsonFileParser.h
+++ b/LogMonitor/src/LogMonitor/Parser/JsonFileParser.h
@@ -36,6 +36,8 @@ public:
     DataType GetNextDataType();
 
     const std::wstring& ParseStringValue();
+    const std::double_t& ParseNumericValue();
+    const std::double_t& ParseNumber();
 
     bool ParseBooleanValue();
 
@@ -76,6 +78,11 @@ private:
     //
     std::wstring m_stringValue;
 
+    //
+    // Last parsed numeric value
+    //
+    std::double_t m_doubleValue;
+
     static const int EndOfBuffer = -1;
 
     static inline int HexToInt(
@@ -84,6 +91,10 @@ private:
 
     static inline bool IsWhiteSpace(
         _In_ int Character
+        );
+
+    static inline bool ContainsInfinitySymbol(
+        _In_ std::wstring text
         );
 
     static inline wchar_t ParseSpecialCharacter(int Character);

--- a/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
+++ b/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
@@ -21,6 +21,7 @@
 #define JSON_TAG_FILTER L"filter"
 #define JSON_TAG_INCLUDE_SUBDIRECTORIES L"includeSubdirectories"
 #define JSON_TAG_PROVIDERS L"providers"
+#define JSON_TAG_WAITINSECONDS L"waitInSeconds"
 
 ///
 /// Valid channel attributes
@@ -255,6 +256,9 @@ public:
     std::wstring Filter;
     bool IncludeSubdirectories = false;
 
+    // Default wait time: 5minutes
+    std::double_t WaitInSeconds = 300;
+
     static bool Unwrap(
         _In_ AttributesMap& Attributes,
         _Out_ SourceFile& NewSource)
@@ -291,6 +295,15 @@ public:
             && Attributes[JSON_TAG_INCLUDE_SUBDIRECTORIES] != nullptr)
         {
             NewSource.IncludeSubdirectories = *(bool*)Attributes[JSON_TAG_INCLUDE_SUBDIRECTORIES];
+        }
+
+        //
+        // waitInSeconds is an optional value
+        //
+        if (Attributes.find(JSON_TAG_WAITINSECONDS) != Attributes.end()
+            && Attributes[JSON_TAG_WAITINSECONDS] != nullptr)
+        {
+            NewSource.WaitInSeconds = *(std::double_t*)Attributes[JSON_TAG_WAITINSECONDS];
         }
 
         return true;


### PR DESCRIPTION
# PR Description

If a folder does not exist, wait for a predefined time (user-specified or default). In the logMonitor.json file, we will add a field for wait period, waitInSeconds, which will be the wait time in seconds. The value can range from 0-INFINITY.
-	waitInSeconds = 0
When the value is zero(0), this is means that we do not wait and LogMonitor terminates with an error.
-	waitInSeconds = INFINITY
In this case, LogMonitor will wait for the folder to be created.
-	waitInSeconds = +integer
When the value is a positive integer, LogMonitor will wait for a predefined time. Once the time elapses, LogMonitor will terminate with an error.

**Edge cases:**
- If the user does not specify the value of waitInSeconds, then a default value is used, waitInSeconds = 300, that is, 300seconds (5 minutes).
- If a user provides an invalid value, a value less than 0, an error occurs
![image](https://github.com/microsoft/windows-container-tools/assets/20437227/65d2f473-c659-450a-8820-fc3351a83d3a)
