### PR TITLE
Fix to unblock Event Log failure in runtime:4.8-windowsservercore-ltsc2019 alt

### DIFF
--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -678,7 +678,7 @@ EventMonitor::EnableEventLogChannels()
 
                 if (status == RPC_S_SERVER_UNAVAILABLE)
                 {
-                    elapsedTime += WAIT_INTERVAL;
+                    elapsedTime += Utility::WAIT_INTERVAL;
                 }
                 else
                 {

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -599,10 +599,144 @@ EventMonitor::EnableEventLogChannels()
 {
     for (const auto& eventChannel : m_eventChannels)
     {
-        EnableEventLogChannel(eventChannel.Name.c_str());
+        DWORD status = EnableEventLogChannel(eventChannel.Name.c_str());
+
+        if (status == RPC_S_SERVER_UNAVAILABLE) {
+
+            HANDLE timerEvent = CreateWaitableTimer(NULL, FALSE, NULL);
+
+
+            if (!timerEvent) {
+            status = GetLastError();
+            logWriter.TraceError(
+                Utility::FormatString(
+                    L"Failed to create timer object.", status).c_str());
+                        }
+
+            std::double_t waitInSeconds = 300;
+
+            int elapsedTime = 0;
+
+            const int eventsCount = 2;
+            HANDLE dirOpenEvents[eventsCount] = {m_stopEvent, timerEvent};
+
+            while (elapsedTime < waitInSeconds) {
+
+                int waitInterval = EventMonitor::_GetWaitInterval(waitInSeconds, elapsedTime);
+                LARGE_INTEGER timeToWait = EventMonitor::_ConvertWaitIntervalToLargeInt(waitInterval);
+
+                BOOL waitableTimer = SetWaitableTimer(timerEvent, &timeToWait, 0, NULL, NULL, 0);
+                if (!waitableTimer) {
+                    status = GetLastError();
+                    logWriter.TraceError(
+                        Utility::FormatString(
+                            L"Failed to set timer object to enable %s event channel. Error: %lu",
+                            eventChannel.Name.c_str(),
+                            status).c_str());
+                    break;
+                }
+
+                DWORD wait = WaitForMultipleObjects(eventsCount, dirOpenEvents, FALSE, INFINITE);
+                switch(wait)
+                {
+                    case WAIT_OBJECT_0:
+                    {
+                        //
+                        // The process is exiting. Stop the timer and return.
+                        //
+                        CancelWaitableTimer(timerEvent);
+                        CloseHandle(timerEvent);
+                        // return INVALID_HANDLE_VALUE;
+                    }
+
+                    case WAIT_OBJECT_0 + 1:
+                    {
+                        //
+                        // Timer event. Retry opening directory handle.
+                        //
+                        break;
+                    }
+
+                    default:
+                    {
+                        //
+                        // Wait failed, return the failure.
+                        //
+                        status = GetLastError();
+
+                        CancelWaitableTimer(timerEvent);
+                        CloseHandle(timerEvent);
+
+                    }
+                }
+
+                DWORD status = EnableEventLogChannel(eventChannel.Name.c_str());
+
+                if (status == RPC_S_SERVER_UNAVAILABLE)
+                {
+                    elapsedTime += WAIT_INTERVAL;
+                }
+                else
+                {
+                    logWriter.TraceInfo(
+                        Utility::FormatString(
+                            L"Enabled %s event channel after %d seconds.",
+                            eventChannel.Name.c_str(),
+                            elapsedTime).c_str()
+                    );
+                    status = ERROR_SUCCESS;
+                    break;
+                }
+
+            }
+
+            CancelWaitableTimer(timerEvent);
+            CloseHandle(timerEvent);
+
+            if(elapsedTime < waitInSeconds) 
+        {
+            logWriter.TraceError(
+            Utility::FormatString(
+                L"Failed to enable event channel. Channel: %ws Error: 0x%X",
+                eventChannel.Name.c_str(),
+                status
+            ).c_str()
+        );
+        }
+        
+        }
+
+        
+
     }
 }
 
+
+// Converts the time to wait to a large integer
+LARGE_INTEGER EventMonitor::_ConvertWaitIntervalToLargeInt(int timeInterval)
+{
+    LARGE_INTEGER liDueTime{};
+
+    int millisecondsToWait = timeInterval * 1000;
+    liDueTime.QuadPart = -millisecondsToWait * 10000LL; // wait time in 100 nanoseconds
+    return liDueTime;
+}
+
+// Returns the time (in seconds) to wait based on the specified waitInSeconds
+int EventMonitor::_GetWaitInterval(std::double_t waitInSeconds, int elapsedTime)
+{
+    if (isinf(waitInSeconds)) {
+        return int(WAIT_INTERVAL);
+    }
+
+    if (waitInSeconds < WAIT_INTERVAL)
+    {
+        return int(waitInSeconds);
+    }
+
+    const auto remainingTime = int(waitInSeconds - elapsedTime);
+    return remainingTime <= WAIT_INTERVAL ? remainingTime : WAIT_INTERVAL;
+}
 
 /// Enables or disables an Event Log channel.
 ///
@@ -610,7 +744,7 @@ EventMonitor::EnableEventLogChannels()
 ///
 /// \return None
 ///
-void
+DWORD
 EventMonitor::EnableEventLogChannel(
     _In_ LPCWSTR ChannelPath
     )
@@ -700,8 +834,8 @@ Exit:
 
     if (ERROR_SUCCESS != status)
     {
-        logWriter.TraceError(
-            Utility::FormatString(L"Failed to enable event channel %ws: 0x%X", ChannelPath, status).c_str()
+        logWriter.TraceInfo(
+            Utility::FormatString(L"Waiting for %ws event channel to be enabled", ChannelPath).c_str()
         );
     }
 
@@ -709,4 +843,6 @@ Exit:
     {
         EvtClose(channelConfig);
     }
+
+    return status;
 }

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -601,7 +601,6 @@ EventMonitor::EnableEventLogChannels()
         DWORD status = EnableEventLogChannel(eventChannel.Name.c_str());
 
         if (status == RPC_S_SERVER_UNAVAILABLE) {
-
             HANDLE timerEvent = CreateWaitableTimer(NULL, FALSE, NULL);
 
 
@@ -621,7 +620,6 @@ EventMonitor::EnableEventLogChannels()
             HANDLE channelEnableEvents[eventsCount] = {m_stopEvent, timerEvent};
 
             while (elapsedTime < waitInSeconds) {
-
                 int waitInterval = Utility::GetWaitInterval(waitInSeconds, elapsedTime);
                 LARGE_INTEGER timeToWait = Utility::ConvertWaitIntervalToLargeInt(waitInterval);
 

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -603,14 +603,13 @@ EventMonitor::EnableEventLogChannels()
         if (status == RPC_S_SERVER_UNAVAILABLE) {
             HANDLE timerEvent = CreateWaitableTimer(NULL, FALSE, NULL);
 
-
             if (!timerEvent) {
             status = GetLastError();
             logWriter.TraceError(
                 Utility::FormatString(
                     L"Failed to create timer object.", status).c_str());
             break;
-                        }
+            }
 
             std::double_t waitInSeconds = 300;
 
@@ -622,7 +621,6 @@ EventMonitor::EnableEventLogChannels()
             while (elapsedTime < waitInSeconds) {
                 int waitInterval = Utility::GetWaitInterval(waitInSeconds, elapsedTime);
                 LARGE_INTEGER timeToWait = Utility::ConvertWaitIntervalToLargeInt(waitInterval);
-
                 BOOL waitableTimer = SetWaitableTimer(timerEvent, &timeToWait, 0, NULL, NULL, 0);
                 if (!waitableTimer) {
                     status = GetLastError();

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -618,7 +618,7 @@ EventMonitor::EnableEventLogChannels()
             int elapsedTime = 0;
 
             const int eventsCount = 2;
-            HANDLE dirOpenEvents[eventsCount] = {m_stopEvent, timerEvent};
+            HANDLE channelEnableEvents[eventsCount] = {m_stopEvent, timerEvent};
 
             while (elapsedTime < waitInSeconds) {
 
@@ -636,7 +636,7 @@ EventMonitor::EnableEventLogChannels()
                     break;
                 }
 
-                DWORD wait = WaitForMultipleObjects(eventsCount, dirOpenEvents, FALSE, INFINITE);
+                DWORD wait = WaitForMultipleObjects(eventsCount, channelEnableEvents, FALSE, INFINITE);
                 switch(wait)
                 {
                     case WAIT_OBJECT_0:
@@ -703,7 +703,7 @@ EventMonitor::EnableEventLogChannels()
             ).c_str()
         );
         }
-        
+
         }
 
         

--- a/LogMonitor/src/LogMonitor/EventMonitor.h
+++ b/LogMonitor/src/LogMonitor/EventMonitor.h
@@ -8,6 +8,9 @@
 class EventMonitor final
 {
 public:
+
+    static const int WAIT_INTERVAL = 15;
+
     EventMonitor() = delete;
 
     EventMonitor(
@@ -56,7 +59,14 @@ private:
         _In_ const HANDLE& EventHandle
         );
 
+    static LARGE_INTEGER _ConvertWaitIntervalToLargeInt(
+            int timeInterval);
+
+        static int _GetWaitInterval(
+            std::double_t waitInSeconds,
+            int elapsedTime);
+
     void EnableEventLogChannels();
 
-    static void EnableEventLogChannel(_In_ LPCWSTR ChannelPath);
+    static DWORD EnableEventLogChannel(_In_ LPCWSTR ChannelPath);
 };

--- a/LogMonitor/src/LogMonitor/EventMonitor.h
+++ b/LogMonitor/src/LogMonitor/EventMonitor.h
@@ -9,8 +9,6 @@ class EventMonitor final
 {
 public:
 
-    static const int WAIT_INTERVAL = 15;
-
     EventMonitor() = delete;
 
     EventMonitor(

--- a/LogMonitor/src/LogMonitor/EventMonitor.h
+++ b/LogMonitor/src/LogMonitor/EventMonitor.h
@@ -59,14 +59,9 @@ private:
         _In_ const HANDLE& EventHandle
         );
 
-    static LARGE_INTEGER _ConvertWaitIntervalToLargeInt(
-            int timeInterval);
-
-        static int _GetWaitInterval(
-            std::double_t waitInSeconds,
-            int elapsedTime);
 
     void EnableEventLogChannels();
 
-    static DWORD EnableEventLogChannel(_In_ LPCWSTR ChannelPath);
+    static DWORD EnableEventLogChannel(
+        _In_ LPCWSTR ChannelPath);
 };

--- a/LogMonitor/src/LogMonitor/FileMonitor/FileMonitorUtilities.cpp
+++ b/LogMonitor/src/LogMonitor/FileMonitor/FileMonitorUtilities.cpp
@@ -191,7 +191,7 @@ HANDLE FileMonitorUtilities::_RetryOpenDirectoryWithInterval(
         if (logDirHandle == INVALID_HANDLE_VALUE)
         {
             status = GetLastError();
-            elapsedTime += WAIT_INTERVAL;
+            elapsedTime += Utility::WAIT_INTERVAL;
         }
         else
         {

--- a/LogMonitor/src/LogMonitor/FileMonitor/FileMonitorUtilities.cpp
+++ b/LogMonitor/src/LogMonitor/FileMonitor/FileMonitorUtilities.cpp
@@ -7,7 +7,7 @@
 #include <regex>
 
 /**
- * Warapper around Create Event API
+ * Wrapper around Create Event API
  *
  * @param bManualReset
  * @param bInitialState
@@ -64,7 +64,7 @@ HANDLE FileMonitorUtilities::GetLogDirHandle(
         //
         // Log directory is not created yet. Keep retrying every
         // 15 seconds for upto five minutes. Also start reading the
-        // log files from the begining, instead of current end of
+        // log files from the beginning, instead of current end of
         // file.
         //
         HANDLE timerEvent = CreateWaitableTimer(NULL, FALSE, NULL);
@@ -128,8 +128,8 @@ HANDLE FileMonitorUtilities::_RetryOpenDirectoryWithInterval(
 
     while (FileMonitorUtilities::_IsFileErrorStatus(status) && elapsedTime < waitInSeconds)
     {
-        int waitInterval = FileMonitorUtilities::_GetWaitInterval(waitInSeconds, elapsedTime);
-        LARGE_INTEGER timeToWait = FileMonitorUtilities::_ConvertWaitIntervalToLargeInt(waitInterval);
+        int waitInterval = Utility::GetWaitInterval(waitInSeconds, elapsedTime);
+        LARGE_INTEGER timeToWait = Utility::ConvertWaitIntervalToLargeInt(waitInterval);
 
         BOOL waitableTimer = SetWaitableTimer(timerEvent, &timeToWait, 0, NULL, NULL, 0);
         if (!waitableTimer)
@@ -205,33 +205,6 @@ HANDLE FileMonitorUtilities::_RetryOpenDirectoryWithInterval(
     }
 
     return logDirHandle;
-}
-
-// Converts the time to wait to a large integer
-LARGE_INTEGER FileMonitorUtilities::_ConvertWaitIntervalToLargeInt(int timeInterval)
-{
-    LARGE_INTEGER liDueTime{};
-
-    int millisecondsToWait = timeInterval * 1000;
-    liDueTime.QuadPart = -millisecondsToWait * 10000LL; // wait time in 100 nanoseconds
-    return liDueTime;
-}
-
-// Returns the time (in seconds) to wait based on the specified waitInSeconds
-int FileMonitorUtilities::_GetWaitInterval(std::double_t waitInSeconds, int elapsedTime)
-{
-    if (isinf(waitInSeconds))
-    {
-        return int(WAIT_INTERVAL);
-    }
-
-    if (waitInSeconds < WAIT_INTERVAL)
-    {
-        return int(waitInSeconds);
-    }
-
-    const auto remainingTime = int(waitInSeconds - elapsedTime);
-    return remainingTime <= WAIT_INTERVAL ? remainingTime : WAIT_INTERVAL;
 }
 
 bool FileMonitorUtilities::_IsFileErrorStatus(DWORD status)

--- a/LogMonitor/src/LogMonitor/FileMonitor/FileMonitorUtilities.h
+++ b/LogMonitor/src/LogMonitor/FileMonitor/FileMonitorUtilities.h
@@ -8,7 +8,6 @@
 class FileMonitorUtilities final
 {
     public:
-        static const int WAIT_INTERVAL = 15;
 
         static HANDLE CreateFileMonitorEvent(
             _In_ BOOL bManualReset,

--- a/LogMonitor/src/LogMonitor/FileMonitor/FileMonitorUtilities.h
+++ b/LogMonitor/src/LogMonitor/FileMonitor/FileMonitorUtilities.h
@@ -32,13 +32,6 @@ class FileMonitorUtilities final
             HANDLE stopEvent,
             HANDLE timerEvent);
 
-        static LARGE_INTEGER _ConvertWaitIntervalToLargeInt(
-            int timeInterval);
-
-        static int _GetWaitInterval(
-            std::double_t waitInSeconds,
-            int elapsedTime);
-
         static bool _IsFileErrorStatus(DWORD status);
 
         static std::wstring _GetWaitLogMessage(

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -340,7 +340,7 @@ LogFileMonitor::StartLogFileMonitor()
     {
         m_readLogFilesFromStart = true;
     }
-
+ 
     m_logDirHandle = logDirHandle;
 
     //

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -312,3 +312,34 @@ bool Utility::ConfigAttributeExists(AttributesMap& Attributes, std::wstring attr
     auto it = Attributes.find(attributeName);
     return it != Attributes.end() && it->second != nullptr;
 }
+
+///
+// Converts the time to wait to a large integer
+///
+LARGE_INTEGER Utility::ConvertWaitIntervalToLargeInt(_In_ int timeInterval)
+{
+    LARGE_INTEGER liDueTime{};
+
+    int millisecondsToWait = timeInterval * 1000;
+    liDueTime.QuadPart = -millisecondsToWait * 10000LL;  // wait time in 100 nanoseconds
+    return liDueTime;
+}
+
+///
+/// Returns the time (in seconds) to wait based on the specified waitInSeconds
+///
+int Utility::GetWaitInterval(_In_ std::double_t waitInSeconds, _In_ int elapsedTime)
+{
+    if (isinf(waitInSeconds))
+    {
+        return static_cast<int>(WAIT_INTERVAL);
+    }
+
+    if (waitInSeconds < WAIT_INTERVAL)
+    {
+        return static_cast<int>(waitInSeconds);
+    }
+
+    const auto remainingTime = static_cast<int>(waitInSeconds - elapsedTime);
+    return remainingTime <= WAIT_INTERVAL ? remainingTime : WAIT_INTERVAL;
+}

--- a/LogMonitor/src/LogMonitor/Utility.h
+++ b/LogMonitor/src/LogMonitor/Utility.h
@@ -21,6 +21,9 @@ typedef std::map<std::wstring, void*, CaseInsensitiveWideString> AttributesMap;
 class Utility final
 {
 public:
+
+    static const int WAIT_INTERVAL = 15;
+
     static std::wstring SystemTimeToString(
         SYSTEMTIME SystemTime
     );
@@ -58,9 +61,20 @@ public:
         _In_ const std::wstring& To
     );
 
-    static bool isJsonNumber(_In_ std::wstring& str);
+    static bool isJsonNumber(
+        _In_ std::wstring& str);
 
-    static void SanitizeJson(_Inout_ std::wstring &str);
+    static void SanitizeJson(
+        _Inout_ std::wstring &str);
 
-    static bool ConfigAttributeExists(_In_ AttributesMap &Attributes, _In_ std::wstring attributeName);
+    static bool ConfigAttributeExists(
+        _In_ AttributesMap& Attributes,
+        _In_ std::wstring attributeName);
+
+    static LARGE_INTEGER ConvertWaitIntervalToLargeInt(
+        _In_ int timeInterval);
+
+    static int GetWaitInterval(
+        _In_ std::double_t waitInSeconds,
+        _In_ int elapsedTime);
 };


### PR DESCRIPTION
Error:
![error_2019](https://github.com/microsoft/windows-container-tools/assets/10998352/8c9f6547-735f-4edb-8c47-0a7bb75d4e61)

New Fix:
![fix_2019_alt](https://github.com/microsoft/windows-container-tools/assets/10998352/fa4fcc66-2afe-4533-b3c9-b2160721e08a)

This is a quick fix for this bug : https://github.com/microsoft/windows-container-tools/issues/150

All the steps to repro this are in the link above (the image affected, Dockerfile and LogMonitorConfig.json.

Build without the fix:
[LogMonitor.zip](https://github.com/microsoft/windows-container-tools/files/12715852/LogMonitor.zip)

Build with the fix:
[LogMonitorWithFix.zip](https://github.com/microsoft/windows-container-tools/files/12715806/LogMonitorWithFix.zip)

