### PR TITLE
Fix SanitizeJson when string contains escaped quotes (or nested json)

### DIFF
--- a/LogMonitor/LogMonitorTests/UtilityTests.cpp
+++ b/LogMonitor/LogMonitorTests/UtilityTests.cpp
@@ -82,6 +82,12 @@ namespace UtilityTests
             expect = L"C:\\\\Drive\\\\XX";
             Utility::SanitizeJson(str);
             Assert::IsTrue(str == expect, L"should escape \\");
+
+            str = L"{\"foo\":\"bar\",\"json_in_json\":\"{\\\"key_inner\\\":\\\"value_inner\\\"}\"}";
+            expect = L"{\\\"foo\\\":\\\"bar\\\",\\\"json_in_json\\\":\\\"{\\\\\\\"key_inner\\\\\\\":\\\\\\\"value_inner\\\\\\\"}\\\"}";
+            Utility::SanitizeJson(str);
+            Assert::IsTrue(str == expect, L"should properly escape json inside json");
+
         }
     };
 }

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -265,43 +265,25 @@ bool Utility::isJsonNumber(_In_ std::wstring& str)
 ///
 void Utility::SanitizeJson(_Inout_ std::wstring& str)
 {
-    size_t i = 0;
-    while (i < str.size()) {
+    size_t num_esc = 0;
+    for (size_t i = 0; i < str.size(); i++) {
         auto sub = str.substr(i, 1);
-        if (sub == L"\"") {
-            if ((i > 0 && str.substr(i - 1, 1) != L"\\")
-                || i == 0)
-            {
-                str.replace(i, 1, L"\\\"");
-                i++;
-            }
+        if (sub == L"\"" || sub == L"\\" || sub == L"\n" || sub == L"\r") {
+            num_esc++;
         }
-        else if (sub == L"\\") {
-            if ((i < str.size() - 1 && str.substr(i + 1, 1) != L"\\")
-                || i == str.size() - 1)
-            {
-                str.replace(i, 1, L"\\\\");
-                i++;
-            }
-            else {
-                i += 2;
-            }
-        }
-        else if (sub == L"\n") {
-            if ((i > 0 && str.substr(i - 1, 1) != L"\\")
-                || i == 0)
-            {
-                str.replace(i, 1, L"\\n");
-                i++;
-            }
-        }
-        else if (sub == L"\r") {
-            if ((i > 0 && str.substr(i - 1, 1) != L"\\")
-                || i == 0)
-            {
-                str.replace(i, 1, L"\\r");
-                i++;
-            }
+    }
+
+    str.reserve(str.size() + num_esc);
+    for (size_t i = 0; i < str.size(); i++) {
+        auto sub = str.substr(i, 1);
+        if (sub == L"\n") {
+            str.replace(i, 1, L"\\n");
+        } else if (sub == L"\r") {
+            str.replace(i, 1, L"\\r");
+        } else if (sub == L"\"" || sub == L"\\") {
+            str.insert(i, L"\\");
+        } else {
+            continue;
         }
         i++;
     }


### PR DESCRIPTION
`SanitizeJson` is currently broken for strings containing nested quoted strings (or nested json). The code attempts to check if characters are already escaped, and not escape them again, which means that the nested strings are not properly decoded and break a json lexer in a subsequent log pipeline.

This PR fixes the encoding to be unconditional, specifically:
- every instance of `<cr>` will become `\r`, 
- every instance of `<lf>` will become `\n`, 
- every instance of `"` will become `\"`, and 
- every instance of `\` will become `\\`.

A unit test is added which fails against the repo as-is, and is also fixed in this PR.

## Example

Assume the json `{"foo":"bar","nested_quotes":"this string \"contains\" quotes"}` is logged from an application as a single line of text.

The current implementation of `SanitizeJson` returns:

```json
"{\"foo\":\"bar\",\"nested_quotes\":\"this string \\"contains\\" quotes\"}"
```

GitHub's syntax highlighting shows the issue above clearly: the nested quotes are missing an extra `\\` and therefore accidentally terminate the *enclosing* string.

After this change:

```json
"{\"foo\":\"bar\",\"nested_quotes\":\"this string \\\"contains\\\" quotes\"}"
```

👌❤️ 
