### PR TITLE
[Fix] Log stream delay when dir does not exist

### DIFF
--- a/LogMonitor/src/LogMonitor/FileMonitor/FileMonitorUtilities.h
+++ b/LogMonitor/src/LogMonitor/FileMonitor/FileMonitorUtilities.h
@@ -36,4 +36,7 @@ class FileMonitorUtilities final
         static std::wstring _GetWaitLogMessage(
             std::wstring logDirectory,
             std::double_t waitInSeconds);
+
+        static std::wstring _GetParentDir(
+            std::wstring dirPath);
 };

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -62,7 +62,7 @@ LogFileMonitor::LogFileMonitor(_In_ const std::wstring& LogDirectory,
     // By default, the name is limited to MAX_PATH characters. To extend this limit to 32,767 wide characters,
     // we prepend "\?" to the path. Prepending the string "\?" does not allow access to the root directory
     // We, therefore, do not prepend for the root directory
-    bool isRootFolder = CheckIsRootFolder(m_logDirectory);
+    bool isRootFolder = FileMonitorUtilities::CheckIsRootFolder(m_logDirectory);
     m_logDirectory = isRootFolder ? m_logDirectory : PREFIX_EXTENDED_PATH + m_logDirectory;
 
     if (m_filter.empty())
@@ -215,7 +215,8 @@ LogFileMonitor::StartLogFileMonitorStatic(
         {
             logWriter.TraceError(
                 Utility::FormatString(
-                    L"Failed to start log file monitor. Log files in a directory %s will not be monitored. Error: %lu",
+                    L"Failed to start log file monitor. Log files in a directory "
+                    "'%s' will not be monitored. Error: %lu",
                     pThis->m_logDirectory.c_str(),
                     status
                 ).c_str()
@@ -227,7 +228,8 @@ LogFileMonitor::StartLogFileMonitorStatic(
     {
         logWriter.TraceError(
             Utility::FormatString(
-                L"Failed to start log file monitor. Log files in a directory %s will not be monitored. %S",
+                L"Failed to start log file monitor. Log files in a directory "
+                "'%s' will not be monitored. %S",
                 pThis->m_logDirectory.c_str(),
                 ex.what()
             ).c_str()
@@ -238,7 +240,7 @@ LogFileMonitor::StartLogFileMonitorStatic(
     {
         logWriter.TraceError(
             Utility::FormatString(
-                L"Failed to start log file monitor. Log files in a directory %s will not be monitored.",
+                L"Failed to start log file monitor. Log files in a directory '%s' will not be monitored.",
                 pThis->m_logDirectory.c_str()
             ).c_str()
         );
@@ -2042,13 +2044,4 @@ LogFileMonitor::GetFileId(
     }
 
     return status;
-}
-
-bool
-LogFileMonitor::CheckIsRootFolder(_In_ std::wstring dirPath)
-{
-    std::wregex pattern(L"^\\w:?$");
-
-    std::wsmatch matches;
-    return std::regex_search(dirPath, matches, pattern);
 }

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.h
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.h
@@ -5,18 +5,22 @@
 
 #pragma once
 
-#define REVERSE_BYTE_ORDER_MARK 0xFFFE
-#define BYTE_ORDER_MARK         0xFEFF
+#include <vector>
+#include <memory>
 
-#define BOM_UTF8_HALF           0xBBEF
-#define BOM_UTF8_2HALF          0xBF
+#define REVERSE_BYTE_ORDER_MARK 0xFFFE
+#define BYTE_ORDER_MARK 0xFEFF
+
+#define BOM_UTF8_HALF 0xBBEF
+#define BOM_UTF8_2HALF 0xBF
 
 #define PREFIX_EXTENDED_PATH L"\\\\?\\"
 
 ///
 /// LogMonitor filetype
 ///
-enum LM_FILETYPE {
+enum LM_FILETYPE
+{
     FileTypeUnknown,
     ANSI,
     UTF16LE,
@@ -43,7 +47,6 @@ enum class EventAction
     Unknown = 5,
 };
 
-
 struct DirChangeNotificationEvent
 {
     std::wstring FileName;
@@ -51,18 +54,16 @@ struct DirChangeNotificationEvent
     UINT64 Timestamp;
 };
 
-
 class LogFileMonitor final
 {
 public:
     LogFileMonitor() = delete;
 
     LogFileMonitor(
-        _In_ const std::wstring& LogDirectory,
-        _In_ const std::wstring& Filter,
+        _In_ const std::wstring &LogDirectory,
+        _In_ const std::wstring &Filter,
         _In_ bool IncludeSubfolders,
-        _In_ const std::double_t& WaitInSeconds
-        );
+        _In_ const std::double_t &WaitInSeconds);
 
     ~LogFileMonitor();
 
@@ -112,7 +113,7 @@ private:
     //
     struct ci_less
     {
-        bool operator() (const std::wstring & s1, const std::wstring & s2) const
+        bool operator()(const std::wstring &s1, const std::wstring &s2) const
         {
             return _wcsicmp(s1.c_str(), s2.c_str()) < 0;
         }
@@ -129,11 +130,11 @@ private:
     //
     struct file_id_less
     {
-        bool operator() (const FILE_ID_INFO& id1, const FILE_ID_INFO& id2) const
+        bool operator()(const FILE_ID_INFO &id1, const FILE_ID_INFO &id2) const
         {
             return id1.VolumeSerialNumber < id2.VolumeSerialNumber ||
-                (id1.VolumeSerialNumber == id2.VolumeSerialNumber
-                    && memcmp(id1.FileId.Identifier, id2.FileId.Identifier, sizeof(id1.FileId.Identifier)) < 0);
+                   (id1.VolumeSerialNumber == id2.VolumeSerialNumber &&
+                    memcmp(id1.FileId.Identifier, id2.FileId.Identifier, sizeof(id1.FileId.Identifier)) < 0);
         }
     };
 
@@ -148,82 +149,69 @@ private:
     DWORD StartLogFileMonitor();
 
     static DWORD StartLogFileMonitorStatic(
-        _In_ LPVOID Context
-        );
+        _In_ LPVOID Context);
 
     static inline BOOL FileMatchesFilter(
         _In_ LPCWSTR FileName,
-        _In_ LPCWSTR SearchPattern
-        );
+        _In_ LPCWSTR SearchPattern);
 
     DWORD InitializeMonitoredFilesInfo();
 
     DWORD LogDirectoryChangeNotificationHandler();
 
     static DWORD LogFilesChangeHandlerStatic(
-        _In_ LPVOID Context
-        );
+        _In_ LPVOID Context);
 
     DWORD LogFilesChangeHandler();
 
     DWORD InitializeDirectoryChangeEventsQueue();
 
     static DWORD GetFilesInDirectory(
-        _In_ const std::wstring& FolderPath,
-        _In_ const std::wstring& SearchPattern,
-        _Out_ std::vector<std::pair<std::wstring, FILE_ID_INFO>>& Files,
-        _In_ bool ShouldLookInSubfolders
-        );
+        _In_ const std::wstring &FolderPath,
+        _In_ const std::wstring &SearchPattern,
+        _Out_ std::vector<std::pair<std::wstring, FILE_ID_INFO>> &Files,
+        _In_ bool ShouldLookInSubfolders);
 
-    DWORD LogFileAddEventHandler(DirChangeNotificationEvent& Event);
+    DWORD LogFileAddEventHandler(DirChangeNotificationEvent &Event);
 
-    DWORD LogFileRemoveEventHandler(DirChangeNotificationEvent& Event);
+    DWORD LogFileRemoveEventHandler(DirChangeNotificationEvent &Event);
 
-    DWORD LogFileModifyEventHandler(DirChangeNotificationEvent& Event);
+    DWORD LogFileModifyEventHandler(DirChangeNotificationEvent &Event);
 
-    DWORD LogFileRenameNewEventHandler(DirChangeNotificationEvent& Event);
+    DWORD LogFileRenameNewEventHandler(DirChangeNotificationEvent &Event);
 
     void RenameFileInMaps(
-        _In_ const std::wstring& NewFullName,
-        _In_ const std::wstring& OldName,
-        _In_ const FILE_ID_INFO& FileId
-        );
+        _In_ const std::wstring &NewFullName,
+        _In_ const std::wstring &OldName,
+        _In_ const FILE_ID_INFO &FileId);
 
-    DWORD LogFileReInitEventHandler(DirChangeNotificationEvent& Event);
+    DWORD LogFileReInitEventHandler(DirChangeNotificationEvent &Event);
 
     DWORD ReadLogFile(
-        _Inout_ std::shared_ptr<LogFileInformation> LogFileInfo
-        );
+        _Inout_ std::shared_ptr<LogFileInformation> LogFileInfo);
 
     void WriteToConsole(
         _In_ std::wstring Message,
-        _In_ std::wstring FileName
-    );
+        _In_ std::wstring FileName);
 
     LM_FILETYPE FileTypeFromBuffer(
         _In_reads_bytes_(ContentSize) LPBYTE FileContents,
         _In_ UINT ContentSize,
         _In_reads_bytes_(BomSize) LPBYTE Bom,
         _In_ UINT BomSize,
-        _Out_ UINT& FoundBomSize
-        );
+        _Out_ UINT &FoundBomSize);
 
     std::wstring ConvertStringToUTF16(
         _In_reads_bytes_(StringSize) LPBYTE StringPtr,
         _In_ UINT StringSize,
-        _In_ LM_FILETYPE EncodingType
-        );
+        _In_ LM_FILETYPE EncodingType);
 
     LogFileInfoMap::iterator GetLogFilesInformationIt(
-        _In_ const std::wstring& Key,
-        _Out_opt_ bool* IsShortPath = NULL
-        );
+        _In_ const std::wstring &Key,
+        _Out_opt_ bool *IsShortPath = NULL);
 
     static DWORD GetFileId(
-        _In_ const std::wstring& FullLongPath,
-        _Out_ FILE_ID_INFO& FileId,
-        _In_opt_ HANDLE Handle = INVALID_HANDLE_VALUE
-        );
-
-    static bool CheckIsRootFolder(_In_ std::wstring dirPath);
+        _In_ const std::wstring &FullLongPath,
+        _Out_ FILE_ID_INFO &FileId,
+        _In_opt_ HANDLE Handle = INVALID_HANDLE_VALUE);
 };


### PR DESCRIPTION
## What does this PR do?
This PR fixes LogMonitor tool missing the first few log lines when the log file and directory are created after the LogMonitor tool has started. Issue #170

This regression is caused by the PR [#149](https://github.com/microsoft/windows-container-tools/pull/149). The  WaitForMultipleObjects() function waits until the timer expires even though the object is already created during the wait interval.

### Summary of Fix

The fix adds a waitable object on the directory that the LogMonitor tool is observing. The [WaitForMultipleObjects()](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitformultipleobjects) function waits until either the timer expires or the specified file is created. By including the handle of the waitable object in the array, the function can return as soon as the file is created.

This way, the system does not have to wait for the entire duration specified by the timer if the file is created during the wait period. This makes the file monitoring more responsive and efficient.