### PR TITLE
fix process monitor formatting

### DIFF
--- a/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
@@ -238,7 +238,7 @@ size_t bufferCopyAndSanitize(char* dst, char* src)
 size_t formatProcessLog(char* chBuf)
 {
     const char* prefix;
-    const char* suffix;  
+    const char* suffix;
     if (Utility::CompareWStrings(settings.LogFormat, L"XML"))
     {
         prefix = "<Log><Source>Process</Source><LogEntry><Logline>";
@@ -248,7 +248,6 @@ size_t formatProcessLog(char* chBuf)
         prefix = "{\"Source\":\"Process\",\"LogEntry\":{\"Logline\":\"";
         suffix = "\"},\"SchemaVersion\":\"1.0.0\"}\n";
     }
-
     char chBufCpy[BUFSIZE] = "";
 
     //

--- a/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
@@ -238,17 +238,17 @@ size_t bufferCopyAndSanitize(char* dst, char* src)
 size_t formatProcessLog(char* chBuf)
 {
     const char* prefix;
-    const char* suffix;
-    if (Utility::CompareWStrings(settings.LogFormat, L"JSON"))
+    const char* suffix;  
+    if (Utility::CompareWStrings(settings.LogFormat, L"XML"))
     {
-        // {"Source":"Process","LogEntry":{"Logline":"<chBuf>"},"SchemaVersion":"1.0.0"}
-        prefix = "{\"Source\":\"Process\",\"LogEntry\":{\"Logline\":\"";
-        suffix = "\"},\"SchemaVersion\":\"1.0.0\"}\n";
-    } else {
-        // <Log><Source>Process</Source><LogEntry><Logline><chBuf>Z</Logline></LogEntry></Log>
         prefix = "<Log><Source>Process</Source><LogEntry><Logline>";
         suffix = "</Logline></LogEntry></Log>\n";
-    }    
+    }
+    else {
+        prefix = "{\"Source\":\"Process\",\"LogEntry\":{\"Logline\":\"";
+        suffix = "\"},\"SchemaVersion\":\"1.0.0\"}\n";
+    }
+
     char chBufCpy[BUFSIZE] = "";
 
     //
@@ -268,11 +268,12 @@ size_t formatProcessLog(char* chBuf)
     // reset the start index
     if ((index + suffixLen) > BUFSIZE - 5) {
         index = BUFSIZE - 5 - suffixLen;
-        if (Utility::CompareWStrings(settings.LogFormat, L"JSON"))
+        if (Utility::CompareWStrings(settings.LogFormat, L"XML"))
         {
-            suffix = "...\"},\"SchemaVersion\":\"1.0.0\"}\n";
-        } else {
             suffix = "...\</Logline></LogEntry></Log>\n";
+        }
+        else {
+            suffix = "...\"},\"SchemaVersion\":\"1.0.0\"}\n";
         }
     }
 


### PR DESCRIPTION
Addressing  issue: https://github.com/microsoft/windows-container-tools/issues/171

**Issue Description:**

Log Monitor allows users to specify the log format _(Custom, JSON, or XML)_ for ETW, Event logs, and File logs through the respective sections in the config.json file.

However, in the case of process monitor logs, whose specifications are not captured in the config file, the logs should default to JSON unless the user specifies XML as the desired log format.

In the current implementation _(in  rc2.1.0)_, the default log format is XML unless JSON is specified. This is why when rc2.1.0 users specify `"logFormat": "custom" ` the process monitor logs default to XML format.

For example:
![image](https://github.com/microsoft/windows-container-tools/assets/28774968/f20ac559-2bf5-4935-8e23-a6a80b6c7b6a)


This change ensures that the default log format is `JSON`