### PR TITLE
Process Monitor Custom Logging

### DIFF
--- a/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
+++ b/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
@@ -1543,5 +1543,47 @@ namespace LogMonitorTests
             Assert::AreEqual(succcess, true);
         }
 
+        TEST_METHOD(TestSourceProcess)
+        {
+            //
+            // Template of a valid configuration string, with a process source.
+            //
+            std::wstring configFileStrFormat =
+                L"{    \
+                    \"LogConfig\": {    \
+                        \"logFormat\": \"%s\",\
+                        \"sources\": [ \
+                            {\
+                                \"type\": \"Process\",\
+                                \"customLogFormat\": \"%s\"\
+                            }\
+                        ]\
+                    }\
+                }";
+
+            std::wstring logFormat = L"custom";
+            std::wstring customLogFormat = L"{'TimeStamp':'%TimeStamp%', 'source':'%Source%', 'Logline':'%Logline%'}";
+            {
+                std::wstring configFileStr = Utility::FormatString(
+                    configFileStrFormat.c_str(),
+                    logFormat.c_str(),
+                    customLogFormat.c_str()
+                );
+
+                JsonFileParser jsonParser(configFileStr);
+                LoggerSettings settings;
+
+                bool success = ReadConfigFile(jsonParser, settings);
+
+                std::wstring output = RecoverOuput();
+
+                //
+                // The config string was valid
+                //
+                Assert::IsTrue(success);
+                Assert::AreEqual(L"", output.c_str());
+            }
+        }
+
     };
 }

--- a/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
+++ b/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
@@ -620,6 +620,21 @@ AddNewSource(
 
             break;
         }
+
+        case LogSourceType::Process:
+        {
+            std::shared_ptr<SourceProcess> sourceProcess = std::make_shared< SourceProcess>();
+
+            if (!SourceProcess::Unwrap(Attributes, *sourceProcess))
+            {
+                logWriter.TraceError(L"Error parsing configuration file. Invalid Process source)");
+                return false;
+            }
+
+            Sources.push_back(std::reinterpret_pointer_cast<LogSource>(std::move(sourceProcess)));
+
+            break;
+        }
     }
     return true;
 }

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -86,6 +86,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
     std::wstring logFormat = settings.LogFormat;
     std::wstring eventCustomLogFormat;
     std::wstring etwCustomLogFormat;
+    std::wstring processCustomLogFormat;
 
     for (auto source : settings.Sources)
     {
@@ -155,6 +156,14 @@ void StartMonitors(_In_ LoggerSettings& settings)
 
                 etwMonMultiLine = sourceETW->EventFormatMultiLine;
                 etwCustomLogFormat = sourceETW->CustomLogFormat;
+
+                break;
+            }
+            case LogSourceType::Process:
+            {
+                std::shared_ptr<SourceProcess> sourceProcess = std::reinterpret_pointer_cast<SourceProcess>(source);
+
+                processCustomLogFormat = sourceProcess->CustomLogFormat;
 
                 break;
             }

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -86,7 +86,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
     std::wstring logFormat = settings.LogFormat;
     std::wstring eventCustomLogFormat;
     std::wstring etwCustomLogFormat;
-    std::wstring processCustomLogFormat;
+    //CLEAN UP: std::wstring processCustomLgFormat;
 
     for (auto source : settings.Sources)
     {
@@ -159,14 +159,16 @@ void StartMonitors(_In_ LoggerSettings& settings)
 
                 break;
             }
-            case LogSourceType::Process:
+            //CLEAN UP: 
+            
+            /*case LogSourceType::Process:
             {
                 std::shared_ptr<SourceProcess> sourceProcess = std::reinterpret_pointer_cast<SourceProcess>(source);
 
                 processCustomLogFormat = sourceProcess->CustomLogFormat;
 
                 break;
-            }
+            }*/ 
         } // Switch
     }
 

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -26,7 +26,6 @@ std::vector<std::shared_ptr<LogFileMonitor>> g_logfileMonitors;
 std::unique_ptr<EtwMonitor> g_etwMon(nullptr);
 std::wstring logFormat, processMonitorCustomFormat;
 
-
 BOOL WINAPI ControlHandle(_In_ DWORD dwCtrlType)
 {
     switch (dwCtrlType)
@@ -161,7 +160,6 @@ void StartMonitors(_In_ LoggerSettings& settings)
 
                 break;
             }
-            //CLEAN UP: 
             
             case LogSourceType::Process:
             {

--- a/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
+++ b/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
@@ -438,7 +438,7 @@ public:
 class SourceProcess : LogSource
 {
 public:
-    std::wstring CustomLogFormat = L"[%TimeStamp%] [%Source%] [%FileName%] %Message%";
+    std::wstring CustomLogFormat = L"[%TimeStamp%] [%Source%] [%LogEntry%]";
 
     static bool Unwrap(
         _In_ AttributesMap& Attributes,

--- a/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
+++ b/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
@@ -145,7 +145,8 @@ enum class LogSourceType
 {
     EventLog = 0,
     File,
-    ETW
+    ETW,
+    Process
 };
 
 ///
@@ -154,7 +155,8 @@ enum class LogSourceType
 const LPCWSTR LogSourceTypeNames[] = {
     L"EventLog",
     L"File",
-    L"ETW"
+    L"ETW",
+    L"Process"
 };
 
 ///
@@ -425,6 +427,33 @@ public:
             NewSource.CustomLogFormat = *(std::wstring*)Attributes[JSON_TAG_CUSTOM_LOG_FORMAT];
         }
 
+
+        return true;
+    }
+};
+
+///
+/// Represents a Source if Proccess type
+///
+class SourceProcess : LogSource
+{
+public:
+    std::wstring CustomLogFormat = L"[%TimeStamp%] [%Source%] [%FileName%] %Message%";
+
+    static bool Unwrap(
+        _In_ AttributesMap& Attributes,
+        _Out_ SourceProcess& NewSource)
+    {
+        NewSource.Type = LogSourceType::Process;
+
+        //
+        // lineLogFormat is an optional value
+        //
+        if (Attributes.find(JSON_TAG_CUSTOM_LOG_FORMAT) != Attributes.end()
+            && Attributes[JSON_TAG_CUSTOM_LOG_FORMAT] != nullptr)
+        {
+            NewSource.CustomLogFormat = *(std::wstring*)Attributes[JSON_TAG_CUSTOM_LOG_FORMAT];
+        }
 
         return true;
     }

--- a/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
@@ -40,6 +40,10 @@ DWORD CreateAndMonitorProcess(std::wstring& Cmdline, LoggerSettings& Config)
     saAttr.bInheritHandle = TRUE;
     saAttr.lpSecurityDescriptor = NULL;
 
+    // ADD ONTO THIS //
+    std::wstring logFormat = settings.LogFormat;
+    std::wstring processCustomLogFormat;
+
     //
     // Create a pipe for the child process's STDOUT.
     //
@@ -239,6 +243,17 @@ size_t formatProcessLog(char* chBuf)
 {
     const char* prefix;
     const char* suffix;
+    if (Utility::CompareWStrings(m_logFormat, L"Custom")) {
+        
+        //provided format
+
+        //generate custom logs using provide format
+        //formattedFileEntry = Utility::FormatEventLineLog(m_customLogFormat, pLogEntry, pLogEntry->source);
+    }
+    else {
+        //hard coded
+    }
+
     if (Utility::CompareWStrings(settings.LogFormat, L"JSON"))
     {
         // {"Source":"Process","LogEntry":{"Logline":"<chBuf>"},"SchemaVersion":"1.0.0"}
@@ -389,4 +404,17 @@ DWORD ReadFromPipe(LPVOID Param)
     }
 
     return ERROR_SUCCESS;
+}
+
+std::wstring ProcessFieldsMapping(_In_ std::wstring fileFields, _In_ void* pLogEntryData)
+{
+    std::wostringstream oss;
+    FileLogEntry* pLogEntry = (FileLogEntry*)pLogEntryData;
+
+    if (Utility::CompareWStrings(fileFields, L"TimeStamp")) oss << pLogEntry->currentTime;
+    if (Utility::CompareWStrings(fileFields, L"FileName")) oss << pLogEntry->fileName;
+    if (Utility::CompareWStrings(fileFields, L"Source")) oss << pLogEntry->source;
+    if (Utility::CompareWStrings(fileFields, L"Message")) oss << pLogEntry->message;
+
+    return oss.str();
 }

--- a/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
@@ -144,7 +144,7 @@ DWORD CreateChildProcess(std::wstring& Cmdline)
         );
     }
     else
-    {      
+    {
         CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)&ReadFromPipe, NULL, 0, NULL);
         WaitForSingleObject(piProcInfo.hProcess, INFINITE);
 
@@ -301,8 +301,8 @@ size_t formatStandardLog(char* chBuf) {
     index = bufferCopy(chBuf, chBufCpy, index);
 
     // truncate, in the unlikely event of a long logline > |BUFSIZE-85|
-        // leave at least 36 slots for JSON or 21 slots for XML
-        // reset the start index
+    // leave at least 36 slots for JSON or 21 slots for XML
+    // reset the start index
     if ((index + suffixLen) > BUFSIZE - 5) {
         index = BUFSIZE - 5 - suffixLen;
         if (Utility::CompareWStrings(loggingformat, L"XML"))
@@ -388,7 +388,6 @@ DWORD ReadFromPipe(LPVOID Param)
                 if (outSz > 0) {
                     // print out and reset chBufOut and outSz
                     size_t sz = formatProcessLog(chBufOut);
-
                     DWORD dwRead = static_cast<DWORD>(sz);
 
                     bSuccess = logWriter.WriteLog(

--- a/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
@@ -265,7 +265,7 @@ size_t formatCustomLog(char* chBuf) {
     logEntry.logLine = fromBytesconverter.from_bytes(chBufCpy);
 
     std::wstring_convert<std::codecvt_utf8<wchar_t>> toBytesconverter;
-    std::string str = toBytesconverter.to_bytes(Utility::FormatEventLineLog(processCustomLogFormat, &logEntry, logEntry.source));
+    std::string str = toBytesconverter.to_bytes(Utility::FormatEventLineLog(processCustomLogFormat, &logEntry, logEntry.source)) + "\n";
 
     const char* logLine = str.c_str();
     size_t logLineLen = strlen(logLine);

--- a/LogMonitor/src/LogMonitor/ProcessMonitor.h
+++ b/LogMonitor/src/LogMonitor/ProcessMonitor.h
@@ -5,18 +5,35 @@
 
 #pragma once
 
-DWORD CreateAndMonitorProcess(std::wstring& Cmdline, LoggerSettings& Config);
-std::wstring m_logFormat;
+struct ProcessLogEntry {
+    std::wstring source;
+    std::wstring currentTime;
+    std::wstring logLine;
+};
+
+DWORD CreateAndMonitorProcess(std::wstring& Cmdline, std::wstring LogFormat, std::wstring ProcessCustomLogFormat);
+
+DWORD CreateChildProcess(std::wstring& Cmdline);
+
+static DWORD ReadFromPipe(LPVOID Param);
+
+static size_t clearBuffer(char* chBuf);
+
+size_t formatProcessLog(char* chBuf);
+
+size_t formatCustomLog(char* chBuf);
+
+size_t formatStandardLog(char* chBuf);
+
+static size_t bufferCopy(char* dst, char* src, size_t start, size_t end);
+
+static size_t bufferCopyAndSanitize(char* dst, char* src);
 
 class ProcessMonitor final
 {
 public:
-    ProcessMonitor() = delete;
+    ProcessMonitor();
 
-    ProcessMonitor(
-        _In_ const std::wstring& customLogFormat
-    );
-
-    ~ProcessMonitor();
+    static std::wstring ProcessFieldsMapping(_In_ std::wstring eventFields, _In_ void* pLogEntryData);
 
 };

--- a/LogMonitor/src/LogMonitor/ProcessMonitor.h
+++ b/LogMonitor/src/LogMonitor/ProcessMonitor.h
@@ -6,6 +6,7 @@
 #pragma once
 
 DWORD CreateAndMonitorProcess(std::wstring& Cmdline, LoggerSettings& Config);
+std::wstring m_logFormat;
 
 class ProcessMonitor final
 {

--- a/LogMonitor/src/LogMonitor/ProcessMonitor.h
+++ b/LogMonitor/src/LogMonitor/ProcessMonitor.h
@@ -7,3 +7,15 @@
 
 DWORD CreateAndMonitorProcess(std::wstring& Cmdline, LoggerSettings& Config);
 
+class ProcessMonitor final
+{
+public:
+    ProcessMonitor() = delete;
+
+    ProcessMonitor(
+        _In_ const std::wstring& customLogFormat
+    );
+
+    ~ProcessMonitor();
+
+};

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -354,6 +354,9 @@ std::wstring Utility::FormatEventLineLog(_In_ std::wstring customLogFormat, _In_
             if (sourceType == L"File") {
                 fieldValue = LogFileMonitor::FileFieldsMapping(sub.substr(1, sub_length - 2), pLogEntry);
             }
+            if (sourceType == L"Process") {
+                fieldValue = ProcessMonitor::ProcessFieldsMapping(sub.substr(1, sub_length - 2), pLogEntry);
+            }
             //substitute the field name with value
             customLogFormat.replace(i, sub_length, fieldValue);
 

--- a/LogMonitor/src/LogMonitor/version.h
+++ b/LogMonitor/src/LogMonitor/version.h
@@ -7,7 +7,7 @@
 #define _VERSION_H_
 
 #define LM_MAJORNUMBER          2
-#define LM_MINORNUMBER          0
+#define LM_MINORNUMBER          1
 #define LM_PATCHNUMBER          0
 // removed in support of semantic versioning - https://semver.org
 // major.minor.patch


### PR DESCRIPTION
**Description:**
[Log Monitor rc2.0.1](https://github.com/microsoft/windows-container-tools/releases/tag/v2.0.1) supports custom log formatting for all log sources (ETW, Event logs, and File logs) except for process monitoring. The main issue has been the lack of configuration options for process monitoring logs. This PR introduces the ability to configure a custom log format for process monitoring.


**Sample Configuration:**
```
{
  "LogConfig": {
	"logFormat": "custom",
    "sources": [
	  {
        "type": "EventLog",
        "startAtOldestRecord": true,
        "eventFormatMultiLine": false,
        "channels": [
          {
            "name": "system",
            "level": "Information"
          },
          {
            "name": "application",
            "level": "Error"
          }
        ],
        "customLogFormat": "{'TimeStamp':'%TimeStamp%', 'source':'%Source%', 'Severity':'%Severity%', 'EventID':'%EventID%', 'Message':'%Message%'}|JSON"
      },
      {
        "type": "Process",
        "customLogFormat": "{'TimeStamp':'%TimeStamp%', 'source':'%Source%', 'Logline':'%Logline%'}|JSON" 
      }
    ]
  }
}
```


**Docker File:**
```
FROM mcr.microsoft.com/windows/servercore:ltsc2022
#LogMonitor directory contains LogMonitor.exe and LogMonitorConfig.json file
WORKDIR /LogMonitor
COPY LogMonitorConfig.json .
COPY LogMonitor.exe .

SHELL ["C:\\LogMonitor\\LogMonitor.exe", "cmd", "/S", "/C"]
CMD c:\windows\system32\ping.exe -n 20 localhost
```

**Output:**
```
{"TimeStamp":"2024-07-11T16:07:53.000Z", "source":"Process", "Logline":"Reply from ::1: time<1ms "}
{"TimeStamp":"2024-07-11T16:07:54.000Z", "source":"Process", "Logline":"Reply from ::1: time<1ms "}
{"TimeStamp":"2024-07-11T16:07:55.000Z", "source":"Process", "Logline":"Reply from ::1: time<1ms "}
{"TimeStamp":"2024-07-11T16:07:56.000Z", "source":"Process", "Logline":"Reply from ::1: time<1ms "}
{"TimeStamp":"2024-07-11T16:07:57.000Z", "source":"Process", "Logline":"Reply from ::1: time<1ms "}
{"TimeStamp":"2024-07-11T16:07:58.000Z", "source":"Process", "Logline":"Reply from ::1: time<1ms "}
{"TimeStamp":"2024-07-11T16:07:59.000Z", "source":"Process", "Logline":"Reply from ::1: time<1ms "}
```