### PR TITLE
hack: dockerfiles: start off a nanoserver plus image

### DIFF
--- a/hacks/.gitignore
+++ b/hacks/.gitignore
@@ -1,1 +1,2 @@
 private/
+bin/

--- a/hacks/scripts/dockerfiles/nanoserver_plus/dockerfile
+++ b/hacks/scripts/dockerfiles/nanoserver_plus/dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+
+# this is a minimal image based on nanoserver
+# mainly for the purpose of testing, e.g. integration
+# tests on moby/buildkit.
+
+# before building the image, run ./get_binaries.ps1
+# from the host. This dumps all the required binaries
+# in the ./bin directory that is later moved to
+# C:\Windows\system32 to be accessed within %PATH%
+
+COPY ./bin/* /Windows/System32/

--- a/hacks/scripts/dockerfiles/nanoserver_plus/get_binaries.ps1
+++ b/hacks/scripts/dockerfiles/nanoserver_plus/get_binaries.ps1
@@ -1,0 +1,18 @@
+
+# files to copy from Windows host.
+# this are mainly legacy binaries that don't have any
+# extra dependencies.
+$filePaths = @(
+    "C:\Windows\System32\fc.exe",
+    "C:\Windows\System32\whoami.exe"
+)
+
+$dest = "./bin"
+
+if (-not (Test-Path -Path $dest)) {
+    New-Item -ItemType Directory -Path $dest
+}
+
+foreach ($filePath in $filePaths) {
+    Copy-Item -Path $filePath -Destination $dest
+}


### PR DESCRIPTION
Because of reducing the footprint, nanoserver usually ships with as minimal binaries as possible. A few of those binaries left out are important for running integration tests on [buildkit](https://github.com/moby/buildkit/pull/5139), for example comparing two files with `fc.exe`, that's a legacy tool found at `C:\Windows\System32\fc.exe`. The alternative is to use ServerCore which is very huge, and makes for instance one test to take 10x the time. e.g.
 
With servercore:
```
--- SKIP: TestIntegration (324.19s)
--- PASS: TestIntegration/TestDockerfileDirs/worker=containerd/frontend=builtin (323.70s)
    --- SKIP: TestIntegration/TestDockerfileDirs/worker=containerd/frontend=client (0.44s)
```
 
With nanoserver (plus):
```
 --- SKIP: TestIntegration (27.38s)
    --- PASS: TestIntegration/TestDockerfileDirs/worker=containerd/frontend=builtin (27.04s)
    --- SKIP: TestIntegration/TestDockerfileDirs/worker=containerd/frontend=client (0.29s)
```