### PR TITLE
Include Event Source Name in EventLog Event Log entries

### DIFF
--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -505,7 +505,7 @@ EventMonitor::PrintEvent(
             // Extract the variant values for each queried property. If the variant failed to get a valid type
             // set a default value.
             //
-            std::wstring providerName = (EvtVarTypeString != variants[0].Type) ? L"" : variants[0].StringVal;
+            std::wstring providerName = (EvtVarTypeString != variants[EvtSystemProviderName].Type) ? L"" : variants[EvtSystemProviderName].StringVal;
             std::wstring channelName = (EvtVarTypeString != variants[1].Type) ? L"" : variants[1].StringVal;
             pLogEntry->eventId = (EvtVarTypeUInt16 != variants[2].Type) ? 0 : variants[2].UInt16Val;
             UINT8 level = (EvtVarTypeByte != variants[3].Type) ? 0 : variants[3].ByteVal;
@@ -561,6 +561,7 @@ EventMonitor::PrintEvent(
             if (status == ERROR_SUCCESS)
             {
                 pLogEntry->source = L"EventLog";
+                pLogEntry->eventSource = providerName;
                 pLogEntry->eventTime = Utility::FileTimeToString(fileTimeCreated);
                 pLogEntry->eventChannel = channelName;
                 pLogEntry->eventLevel = c_LevelToString[static_cast<UINT8>(level)];
@@ -572,13 +573,14 @@ EventMonitor::PrintEvent(
                 } else {
                     std::wstring logFmt;
                     if (Utility::CompareWStrings(m_logFormat, L"XML")) {
-                        logFmt = L"<Log><Source>%s</Source><LogEntry><Time>%s</Time>"
+                        logFmt = L"<Log><Source>%s</Source><LogEntry><EventSource>%s</EventSource><Time>%s</Time>"
                                  L"<Channel>%s</Channel><Level>%s</Level>"
                                  L"<EventId>%u</EventId><Message>%s</Message>"
                                  L"</LogEntry></Log>";
                     } else {
                         logFmt = L"{\"Source\": \"%s\","
                                  L"\"LogEntry\": {"
+                                 L"\"EventSource\": \"%s\","
                                  L"\"Time\": \"%s\","
                                  L"\"Channel\": \"%s\","
                                  L"\"Level\": \"%s\","
@@ -595,6 +597,7 @@ EventMonitor::PrintEvent(
                     formattedEvent = Utility::FormatString(
                         logFmt.c_str(),
                         pLogEntry->source.c_str(),
+                        pLogEntry->eventSource.c_str(),
                         pLogEntry->eventTime.c_str(),
                         pLogEntry->eventChannel.c_str(),
                         pLogEntry->eventLevel.c_str(),
@@ -829,6 +832,7 @@ std::wstring EventMonitor::EventFieldsMapping(_In_ std::wstring eventField, _In_
     if (Utility::CompareWStrings(eventField, L"TimeStamp")) oss << pLogEntry->eventTime;
     if (Utility::CompareWStrings(eventField, L"Severity")) oss << pLogEntry->eventLevel;
     if (Utility::CompareWStrings(eventField, L"Source")) oss << pLogEntry->source;
+    if (Utility::CompareWStrings(eventField, L"EventSource")) oss << pLogEntry->eventSource;
     if (Utility::CompareWStrings(eventField, L"EventID")) oss << pLogEntry->eventId;
     if (Utility::CompareWStrings(eventField, L"Message")) oss << pLogEntry->eventMessage;
 

--- a/LogMonitor/src/LogMonitor/EventMonitor.h
+++ b/LogMonitor/src/LogMonitor/EventMonitor.h
@@ -35,6 +35,7 @@ private:
 
     struct EventLogEntry {
         std::wstring source;
+        std::wstring eventSource;
         std::wstring eventTime;
         std::wstring eventChannel;
         std::wstring eventLevel;


### PR DESCRIPTION
With this change Event Log now has the EventSource entry. Observe the example log emitted with this change.

```
{
  "Source": "EventLog",
  "LogEntry": {
    "EventSource": ".NET Runtime",
    "Time": "2024-05-15T23:53:41.000Z",
    "Channel": "Application",
    "Level": "Error",
    "EventId": 1026,
    "Message": "Application: VSUpdateHelper.exe\nFramework Version: v4.0.30319\nDescription: The process was terminated due to an unhandled exception.\nException Info: System.Runtime.InteropServices.COMException\n   at Microsoft.VisualStudio.Setup.Services.ProcessService.GetShellDispatchForLoggedInUser()\n   at Microsoft.VisualStudio.Setup.Services.ProcessService.RunAsLoggedOnUser(System.String, System.String)\n   at Microsoft.VisualStudio.Setup.VSUpdateHelper.ToastService.StartProcess(Microsoft.VisualStudio.Setup.ToastNotifications.ToastMessageType)\n   at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)\n   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)\n   at System.Threading.TimerQueueTimer.CallCallback()\n   at System.Threading.TimerQueueTimer.Fire()\n   at System.Threading.TimerQueue.FireNextTimers()\n\n"
  }
}
```