### PR TITLE
fix file watcher hanging and console write performance

### DIFF
--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1709,7 +1709,7 @@ void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstrin
             msg = Message.substr(start, i - start);
             start = i + 1;
             // remove \r if any, usually before \n
-            if (msg.substr(msg.size() - 1) == L"\r") {
+            if (msg.size() > 0 && msg.substr(msg.size() - 1) == L"\r") {
                 msg.replace(msg.size() - 1, 1, L"");
             }
         }

--- a/LogMonitor/src/LogMonitor/LogWriter.h
+++ b/LogMonitor/src/LogMonitor/LogWriter.h
@@ -19,8 +19,9 @@ public:
         {
             m_isConsole = false;
         }
-
-        m_isConsole = true;
+        else {
+            m_isConsole = true;
+        }
 
         _setmode(_fileno(stdout), _O_U8TEXT);
     };
@@ -67,7 +68,12 @@ public :
         AcquireSRWLockExclusive(&m_stdoutLock);
 
         std::wstring output = LogMessage + L"\n";
-        WriteConsoleW(hConsole, output.c_str(), wcslen(output.c_str()), NULL, NULL);
+
+        if (m_isConsole) {
+            WriteConsoleW(GetStdHandle(STD_OUTPUT_HANDLE), output.c_str(), wcslen(output.c_str()), NULL, NULL);
+        } else {
+            wprintf(output.c_str());
+        }
 
         FlushStdOut();
 
@@ -81,7 +87,13 @@ public :
         AcquireSRWLockExclusive(&m_stdoutLock);
 
         std::wstring output = LogMessage + L"\n";
-        WriteConsoleW(hConsole, output.c_str(), wcslen(output.c_str()), NULL, NULL);
+
+        if (m_isConsole) {
+            WriteConsoleW(GetStdHandle(STD_OUTPUT_HANDLE), output.c_str(), wcslen(output.c_str()), NULL, NULL);
+        } else {
+            wprintf(output.c_str());
+        }
+
         FlushStdOut();
 
         ReleaseSRWLockExclusive(&m_stdoutLock);

--- a/LogMonitor/src/LogMonitor/LogWriter.h
+++ b/LogMonitor/src/LogMonitor/LogWriter.h
@@ -15,8 +15,7 @@ public:
         DWORD dwMode;
         hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 
-        if (!GetConsoleMode(hConsole, &dwMode))
-        {
+        if (!GetConsoleMode(hConsole, &dwMode)) {
             m_isConsole = false;
         }
         else {
@@ -70,7 +69,7 @@ public :
         std::wstring output = LogMessage + L"\n";
 
         if (m_isConsole) {
-            WriteConsoleW(GetStdHandle(STD_OUTPUT_HANDLE), output.c_str(), wcslen(output.c_str()), NULL, NULL);
+            WriteConsoleW(hConsole, output.c_str(), wcslen(output.c_str()), NULL, NULL);
         } else {
             wprintf(output.c_str());
         }
@@ -89,7 +88,7 @@ public :
         std::wstring output = LogMessage + L"\n";
 
         if (m_isConsole) {
-            WriteConsoleW(GetStdHandle(STD_OUTPUT_HANDLE), output.c_str(), wcslen(output.c_str()), NULL, NULL);
+            WriteConsoleW(hConsole, output.c_str(), wcslen(output.c_str()), NULL, NULL);
         } else {
             wprintf(output.c_str());
         }

--- a/LogMonitor/src/LogMonitor/LogWriter.h
+++ b/LogMonitor/src/LogMonitor/LogWriter.h
@@ -13,8 +13,9 @@ public:
         InitializeSRWLock(&m_stdoutLock);
 
         DWORD dwMode;
+        hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 
-        if (!GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &dwMode))
+        if (!GetConsoleMode(hConsole, &dwMode))
         {
             m_isConsole = false;
         }
@@ -29,6 +30,7 @@ public:
 private:
     SRWLOCK m_stdoutLock;
     bool m_isConsole;
+    HANDLE hConsole;
 
     void FlushStdOut()
     {
@@ -64,7 +66,9 @@ public :
     {
         AcquireSRWLockExclusive(&m_stdoutLock);
 
-        wprintf(L"%s\n", LogMessage.c_str());
+        std::wstring output = LogMessage + L"\n";
+        WriteConsoleW(hConsole, output.c_str(), wcslen(output.c_str()), NULL, NULL);
+
         FlushStdOut();
 
         ReleaseSRWLockExclusive(&m_stdoutLock);
@@ -76,7 +80,8 @@ public :
     {
         AcquireSRWLockExclusive(&m_stdoutLock);
 
-        wprintf(L"%s\n", LogMessage.c_str());
+        std::wstring output = LogMessage + L"\n";
+        WriteConsoleW(hConsole, output.c_str(), wcslen(output.c_str()), NULL, NULL);
         FlushStdOut();
 
         ReleaseSRWLockExclusive(&m_stdoutLock);


### PR DESCRIPTION
This PR addresses the following issues:
- we explicitly write wide characters to console and avoid the existing issue where we were taking a performance hit by setting console mode to `utf8` and letting the console implicitly handle the conversion
- file watcher would get stuck when it encounters an empty string and tries to remove a `\n` character. Addressed this by checking for string length first
- WriteConsole writes directly to Console and cannot be redirected, to allow tests to run, added a function to detect console mode and use wprintf when running tests 

fixes: https://github.com/microsoft/windows-container-tools/issues/35
