### PR TITLE
Rename Process Monitor Configuration Fields for Consistency

### DIFF
--- a/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
+++ b/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
@@ -1732,7 +1732,7 @@ namespace LogMonitorTests
                 }";
 
             std::wstring logFormat = L"custom";
-            std::wstring customLogFormat = L"{'TimeStamp':'%TimeStamp%', 'source':'%Source%', 'Logline':'%Logline%'}";
+            std::wstring customLogFormat = L"{'TimeStamp':'%TimeStamp%', 'source':'%Source%', 'Message':'%Message%'}";
             {
                 std::wstring configFileStr = Utility::FormatString(
                     configFileStrFormat.c_str(),

--- a/LogMonitor/docs/README.md
+++ b/LogMonitor/docs/README.md
@@ -412,7 +412,7 @@ Each log source tracked by log monitor <em>(ETW, Log File, Events, and Process M
 <strong>Process Monitor:</strong>
   - `Source`: The log source (Process Monitor)
   - `TimeStamp`: Time at which the process was executed
-  - `Logline` or `logEntry` : The output of the process/command executed
+  - `Message` : The output of the process/command executed
 
 ### Sample Custom Log Configuration
 
@@ -431,18 +431,18 @@ Each log source tracked by log monitor <em>(ETW, Log File, Events, and Process M
             "level": "Information"
           }
         ],
-        "customLogFormat": "{'TimeStamp':'%TimeStamp%', 'source':'%Source%', 'Severity':'%Severity%', 'ProviderId':'%ProviderId%', 'ProviderName':'%ProviderName%', 'EventId':'%EventId%', 'EventData':'%EventData%'}"
+        "customLogFormat": "{'TimeStamp':'%TimeStamp%', 'Source':'%Source%', 'Severity':'%Severity%', 'ProviderId':'%ProviderId%', 'ProviderName':'%ProviderName%', 'EventId':'%EventId%', 'EventData':'%EventData%'}"
       },
       {
         "type": "File",
         "directory": "c:\\inetpub\\logs",
         "filter": "*.log",
         "includeSubdirectories": true,
-        "customLogFormat": "{'message':%Message%,'source':%Source%,'fileName':%FileName%}"
+        "customLogFormat": "{'Message':%Message%,'Source':%Source%,'fileName':%FileName%}"
       },
       {
         "type": "Process",
-        "customLogFormat": "{'TimeStamp':'%TimeStamp%', 'source':'%Source%', 'Logline':'%Logline%'}" 
+        "customLogFormat": "{'TimeStamp':'%TimeStamp%', 'Source':'%Source%', 'Logline':'%Logline%'}" 
       }
     ]
   }
@@ -468,11 +468,11 @@ For example:
                     "level": "Information"
                    }
                  ],
-                "customLogFormat": "{'TimeStamp':'%TimeStamp%', 'source':'%Source%', 'Severity':'%Severity%', 'ProviderId':'%ProviderId%', 'ProviderName':'%ProviderName%', 'EventId':'%EventId%', 'EventData':'%EventData%'}|json"
+                "customLogFormat": "{'TimeStamp':'%TimeStamp%', 'Source':'%Source%', 'Severity':'%Severity%', 'ProviderId':'%ProviderId%', 'ProviderName':'%ProviderName%', 'EventId':'%EventId%', 'EventData':'%EventData%'}|json"
 	      },
           {
             "type": "Process",
-            "customLogFormat": "{'TimeStamp':'%TimeStamp%', 'source':'%Source%', 'Logline':'%Logline%'}|JSON" 
+            "customLogFormat": "{'TimeStamp':'%TimeStamp%', 'Source':'%Source%', 'Message':'%Message%'}|JSON" 
           }
         ]
   }

--- a/LogMonitor/docs/README.md
+++ b/LogMonitor/docs/README.md
@@ -442,7 +442,7 @@ Each log source tracked by log monitor <em>(ETW, Log File, Events, and Process M
       },
       {
         "type": "Process",
-        "customLogFormat": "{'TimeStamp':'%TimeStamp%', 'Source':'%Source%', 'Logline':'%Logline%'}" 
+        "customLogFormat": "{'TimeStamp':'%TimeStamp%', 'Source':'%Source%', 'Message':'%Message%'}" 
       }
     ]
   }

--- a/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
+++ b/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
@@ -445,7 +445,7 @@ public:
 class SourceProcess : LogSource
 {
     public:
-        std::wstring CustomLogFormat = L"[%TimeStamp%] [%Source%] [%LogEntry%]";
+        std::wstring CustomLogFormat = L"[%TimeStamp%] [%Source%] [%Message%]";
 
         static bool Unwrap(
             _In_ AttributesMap& Attributes,

--- a/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
@@ -260,7 +260,7 @@ size_t FormatCustomLog(char* chBuf) {
     logEntry.currentTime = Utility::SystemTimeToString(st).c_str();
 
     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> fromBytesconverter;
-    logEntry.logLine = fromBytesconverter.from_bytes(chBufCpy);
+    logEntry.message = fromBytesconverter.from_bytes(chBufCpy);
 
     std::wstring_convert<std::codecvt_utf8<wchar_t>> toBytesconverter;
     std::wstring formattedLog = Utility::FormatEventLineLog(processCustomLogFormat, &logEntry, logEntry.source);
@@ -432,8 +432,7 @@ std::wstring ProcessMonitor::ProcessFieldsMapping(_In_ std::wstring fileFields, 
 
     if (Utility::CompareWStrings(fileFields, L"TimeStamp")) oss << pLogEntry->currentTime;
     if (Utility::CompareWStrings(fileFields, L"Source")) oss << pLogEntry->source;
-    if (Utility::CompareWStrings(fileFields, L"logLine")
-        || Utility::CompareWStrings(fileFields, L"logEntry")) oss << pLogEntry->logLine;
+    if (Utility::CompareWStrings(fileFields, L"Message")) oss << pLogEntry->message;
 
     return oss.str();
 }

--- a/LogMonitor/src/LogMonitor/ProcessMonitor.h
+++ b/LogMonitor/src/LogMonitor/ProcessMonitor.h
@@ -8,7 +8,7 @@
 struct ProcessLogEntry {
     std::wstring source;
     std::wstring currentTime;
-    std::wstring logLine;
+    std::wstring message;
 };
 
 DWORD CreateAndMonitorProcess(std::wstring& Cmdline, std::wstring LogFormat, std::wstring ProcessCustomLogFormat);


### PR DESCRIPTION
**Summary of Changes:**

To ensure consistency across various log sources such as Events and File Logs, the process monitor field name has been updated from `Logline` or `LogEntry` to `Message`.

**Testing Instructions:**

Please refer to the testing guidelines provided in this PR: https://github.com/microsoft/windows-container-tools/pull/176

**Test Result:**

![image](https://github.com/user-attachments/assets/d1bf5d50-e02d-4a17-bc57-2a6cb5372c1b)

![image](https://github.com/user-attachments/assets/071a1fc7-ea9b-4220-8862-bf75bb8f1bed)

