### PR TITLE
revert: explicitly write wide string characters to console 

### DIFF
--- a/LogMonitor/src/LogMonitor/LogWriter.h
+++ b/LogMonitor/src/LogMonitor/LogWriter.h
@@ -13,14 +13,13 @@ public:
         InitializeSRWLock(&m_stdoutLock);
 
         DWORD dwMode;
-        hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 
-        if (!GetConsoleMode(hConsole, &dwMode)) {
+        if (!GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &dwMode))
+        {
             m_isConsole = false;
         }
-        else {
-            m_isConsole = true;
-        }
+
+        m_isConsole = true;
 
         _setmode(_fileno(stdout), _O_U8TEXT);
     };
@@ -30,7 +29,6 @@ public:
 private:
     SRWLOCK m_stdoutLock;
     bool m_isConsole;
-    HANDLE hConsole;
 
     void FlushStdOut()
     {
@@ -66,14 +64,7 @@ public :
     {
         AcquireSRWLockExclusive(&m_stdoutLock);
 
-        std::wstring output = LogMessage + L"\n";
-
-        if (m_isConsole) {
-            WriteConsoleW(hConsole, output.c_str(), wcslen(output.c_str()), NULL, NULL);
-        } else {
-            wprintf(output.c_str());
-        }
-
+        wprintf(L"%s\n", LogMessage.c_str());
         FlushStdOut();
 
         ReleaseSRWLockExclusive(&m_stdoutLock);
@@ -85,14 +76,7 @@ public :
     {
         AcquireSRWLockExclusive(&m_stdoutLock);
 
-        std::wstring output = LogMessage + L"\n";
-
-        if (m_isConsole) {
-            WriteConsoleW(hConsole, output.c_str(), wcslen(output.c_str()), NULL, NULL);
-        } else {
-            wprintf(output.c_str());
-        }
-
+        wprintf(L"%s\n", LogMessage.c_str());
         FlushStdOut();
 
         ReleaseSRWLockExclusive(&m_stdoutLock);

--- a/LogMonitor/src/LogMonitor/version.h
+++ b/LogMonitor/src/LogMonitor/version.h
@@ -8,7 +8,7 @@
 
 #define LM_MAJORNUMBER          2
 #define LM_MINORNUMBER          1
-#define LM_PATCHNUMBER          0
+#define LM_PATCHNUMBER          1
 // removed in support of semantic versioning - https://semver.org
 // major.minor.patch
 // #define LM_BUILDMINORVERSION    0


### PR DESCRIPTION
reverts changes from this [PR](https://github.com/microsoft/windows-container-tools/pull/183). 

- WriteConsoleW output cannot be redirected causing a failure to write to docker logs. 
- Fixes https://github.com/microsoft/windows-container-tools/issues/192