### PR TITLE
Refactor build.cmd to use CMake with vcpkg for Boost JSON installation and configuration

### DIFF
--- a/LogMonitor/LogMonitorTests/CMakeLists.txt
+++ b/LogMonitor/LogMonitorTests/CMakeLists.txt
@@ -33,10 +33,11 @@ set_target_properties(LogMonitorTests PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
 )
 
-# Link LogMonitor and Boost.JSON
-target_link_libraries(LogMonitorTests PRIVATE LogMonitor Boost::json)
+# Link LogMonitorLib and Boost.JSON to the test shared library
+target_link_libraries(LogMonitorTests PRIVATE LogMonitorLib Boost::json)
 
 # Enable testing
 enable_testing()
 
+# Register tests
 add_test(NAME LogMonitorTests COMMAND LogMonitorTests)

--- a/LogMonitor/src/CMakeLists.txt
+++ b/LogMonitor/src/CMakeLists.txt
@@ -4,20 +4,52 @@ project(LogMonitor)
 
 find_package(Boost REQUIRED COMPONENTS json)
 
+# Gather source files
 file(GLOB_RECURSE SourceFiles RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.cpp")
+file(GLOB_RECURSE HeaderFiles RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.h")
 
-# Define LogMonitor as a library
-add_library(LogMonitor ${SourceFiles})
+# Define LogMonitorLib as a static library
+add_library(LogMonitorLib STATIC ${SourceFiles})
+
+# Set the output name of the static library to "LogMonitor.lib"
+set_target_properties(LogMonitorLib PROPERTIES
+    OUTPUT_NAME "LogMonitor"
+)
+
+# Define LogMonitor as an executable
+add_executable(LogMonitor ${SourceFiles})
 
 # Add precompiled headers (PCH)
 target_precompile_headers(LogMonitor PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/LogMonitor/pch.h)
 
-# Include directories for LogMonitor
-target_include_directories(LogMonitor PRIVATE
+# Include directories for both targets
+target_include_directories(LogMonitorLib PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/LogMonitor
-	${CMAKE_CURRENT_SOURCE_DIR}/LogMonitor/FileMonitor
+    ${CMAKE_CURRENT_SOURCE_DIR}/LogMonitor/FileMonitor
     ${Boost_INCLUDE_DIRS}
 )
 
-# Link Boost JSON to LogMonitor
+target_include_directories(LogMonitor PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/LogMonitor
+    ${CMAKE_CURRENT_SOURCE_DIR}/LogMonitor/FileMonitor
+    ${Boost_INCLUDE_DIRS}
+)
+
+# Link Boost JSON to LogMonitor and LogMonitorLib
 target_link_libraries(LogMonitor PRIVATE Boost::json)
+target_link_libraries(LogMonitorLib PRIVATE Boost::json)
+
+# Link the executable with the static library
+target_link_libraries(LogMonitor PRIVATE LogMonitorLib)
+
+# Specify the output name for the executable
+set_target_properties(LogMonitor PROPERTIES
+    OUTPUT_NAME "LogMonitor"
+)
+
+# Specify output directories
+set_target_properties(LogMonitor PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,9 +30,9 @@ jobs:
             .\bootstrap-vcpkg.bat
             .\vcpkg.exe integrate install  # Integrate vcpkg with MSBuild
 
-      # Install Boost JSON for the selected platform (x64 or ARM64)
+      # Install Boost libraries: JSON, Regex, Algorithm
       - task: PowerShell@2
-        displayName: 'Install Boost JSON'
+        displayName: 'Install Boost Dependencies (JSON, Regex, Algorithm)'
         inputs:
           targetType: 'inline'
           script: |
@@ -40,11 +40,11 @@ jobs:
                 Write-Error "vcpkg.exe not found. Exiting..."
                 exit 1
             }
-            Write-Host "Installing Boost JSON for platform: $(buildPlatform)..."
+            Write-Host "Installing Boost libraries for platform: $(buildPlatform)..."
             if ('$(buildPlatform)' -eq 'x64') {
-              & "$(VCPKG_ROOT)\vcpkg.exe" install boost-json:x64-windows
+              & "$(VCPKG_ROOT)\vcpkg.exe" install boost-json:x64-windows boost-regex:x64-windows boost-algorithm:x64-windows
             } elseif ('$(buildPlatform)' -eq 'ARM64') {
-              & "$(VCPKG_ROOT)\vcpkg.exe" install boost-json:arm64-windows
+              & "$(VCPKG_ROOT)\vcpkg.exe" install boost-json:arm64-windows boost-regex:arm64-windows boost-algorithm:arm64-windows
             } else {
               Write-Error "Unsupported build platform: $(buildPlatform)"
               exit 1
@@ -58,18 +58,21 @@ jobs:
           script: |
             echo "Verifying vcpkg integration for platform: $(buildPlatform)..."
             & "$(VCPKG_ROOT)\vcpkg.exe" integrate install
-            if ('$(buildPlatform)' -eq 'x64') {
-                if (!(Test-Path "$(VCPKG_ROOT)\installed\x64-windows\include\boost\json.hpp")) {
-                    Write-Error "Boost JSON header not found for x64. Exiting..."
-                    exit 1
-                }
-            } elseif ('$(buildPlatform)' -eq 'ARM64') {
-                if (!(Test-Path "$(VCPKG_ROOT)\installed\arm64-windows\include\boost\json.hpp")) {
-                    Write-Error "Boost JSON header not found for ARM64. Exiting..."
-                    exit 1
-                }
+
+            $basePath = "$(VCPKG_ROOT)\installed\$(buildPlatform)-windows\include"
+            $checks = @(
+              "boost\json.hpp",
+              "boost\regex.hpp",
+              "boost\algorithm\string\replace.hpp"
+            )
+            foreach ($header in $checks) {
+              $path = Join-Path $basePath $header
+              if (!(Test-Path $path)) {
+                Write-Error "Missing header: $path"
+                exit 1
+              }
             }
-            Write-Output "vcpkg integration verified."
+            Write-Output "All Boost headers found."
 
       # Get installed Windows SDK version
       - task: PowerShell@2
@@ -110,7 +113,7 @@ jobs:
         inputs:
           workingDirectory: '$(Build.SourcesDirectory)\LogMonitor'
           cmakeArgs: |
-            -A $(buildPlatform) -S $(Build.SourcesDirectory)\LogMonitor -B $(Build.BinariesDirectory)\LogMonitor\$(buildPlatform)
+            -A $(buildPlatform) -S $(Build.SourcesDirectory)\LogMonitor -B $(Build.BinariesDirectory)\LogMonitor\$(buildPlatform) $(VCPKG_CMAKE_OPTIONS)
 
       - task: CMake@1
         displayName: 'Build with CMake'

--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,45 @@
-msbuild LogMonitor\LogMonitor.sln /p:platform=x64 /p:configuration=Release
+@echo off
+setlocal
+
+REM Set up environment variables
+set VCPKG_DIR=%~dp0vcpkg
+set BUILD_DIR=%~dp0build
+set TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake
+
+REM Step 1: Clone and bootstrap vcpkg if not already done
+if not exist "%VCPKG_DIR%\vcpkg.exe" (
+    echo === Cloning vcpkg ===
+    git clone https://github.com/microsoft/vcpkg.git "%VCPKG_DIR%"
+    echo === Bootstrapping vcpkg ===
+    pushd "%VCPKG_DIR%"
+    .\bootstrap-vcpkg.bat
+    popd
+)
+
+REM Step 2: Install dependencies
+echo === Installing Boost JSON ===
+"%VCPKG_DIR%\vcpkg.exe" install boost-json:x64-windows
+
+REM Step 3: Configure CMake
+echo === Configuring CMake ===
+cmake -S "%~dp0LogMonitor" -B "%BUILD_DIR%" ^
+    -DCMAKE_TOOLCHAIN_FILE="%TOOLCHAIN_FILE%" ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -A x64
+
+if errorlevel 1 (
+    echo CMake configuration failed.
+    exit /b 1
+)
+
+REM Step 4: Build the project
+echo === Building Project ===
+cmake --build "%BUILD_DIR%" --config Release --parallel
+
+if errorlevel 1 (
+    echo Build failed.
+    exit /b 1
+)
+
+echo === Build completed successfully ===
+endlocal

--- a/build.cmd
+++ b/build.cmd
@@ -5,6 +5,8 @@ REM Set up environment variables
 set VCPKG_DIR=%~dp0vcpkg
 set BUILD_DIR=%~dp0build
 set TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake
+set BUILD_TYPE=Release
+set BUILD_ARCH=x64
 
 REM Step 1: Clone and bootstrap vcpkg if not already done
 if not exist "%VCPKG_DIR%\vcpkg.exe" (
@@ -17,15 +19,22 @@ if not exist "%VCPKG_DIR%\vcpkg.exe" (
 )
 
 REM Step 2: Install dependencies
-echo === Installing Boost JSON ===
-"%VCPKG_DIR%\vcpkg.exe" install boost-json:x64-windows
+echo === Installing Boost dependencies ===
+"%VCPKG_DIR%\vcpkg.exe" install boost-json:%BUILD_ARCH%-windows ^
+                               boost-regex:%BUILD_ARCH%-windows ^
+                               boost-algorithm:%BUILD_ARCH%-windows
+
+if errorlevel 1 (
+    echo Failed to install Boost dependencies.
+    exit /b 1
+)
 
 REM Step 3: Configure CMake
 echo === Configuring CMake ===
 cmake -S "%~dp0LogMonitor" -B "%BUILD_DIR%" ^
     -DCMAKE_TOOLCHAIN_FILE="%TOOLCHAIN_FILE%" ^
-    -DCMAKE_BUILD_TYPE=Release ^
-    -A x64
+    -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ^
+    -A %BUILD_ARCH%
 
 if errorlevel 1 (
     echo CMake configuration failed.
@@ -34,12 +43,16 @@ if errorlevel 1 (
 
 REM Step 4: Build the project
 echo === Building Project ===
-cmake --build "%BUILD_DIR%" --config Release --parallel
+cmake --build "%BUILD_DIR%" --config %BUILD_TYPE% --parallel
 
 if errorlevel 1 (
     echo Build failed.
     exit /b 1
 )
+
+REM Optional Step 5: Run tests
+REM echo === Running Tests ===
+REM ctest --test-dir "%BUILD_DIR%" --output-on-failure
 
 echo === Build completed successfully ===
 endlocal


### PR DESCRIPTION
This change refactors the `build.cmd` script to replace the previous MSBuild command with CMake-based build system.

Key Changes:
- Removed `msbuild` command and replaced with CMake configuration.
- Integrated vcpkg for dependency management.
- Added parallel build support and error handling.