### PR TITLE
Nlohmann json Implementation

### DIFF
--- a/LogMonitor/CMakeLists.txt
+++ b/LogMonitor/CMakeLists.txt
@@ -3,21 +3,30 @@ cmake_minimum_required(VERSION 3.15)
 # Define the project
 project(LogMonitor)
 
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+set(Boost_USE_STATIC_LIBS ON)
+set(Boost_USE_STATIC_RUNTIME ON)
+
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_BUILD_TYPE Release)
-set(VCPKG_TARGET_TRIPLET x64-windows)
+set(VCPKG_TARGET_TRIPLET x64-windows-static)
 
 # Use vcpkg if available
-if (DEFINED ENV{VCPKG_ROOT})
+if(DEFINED ENV{VCPKG_ROOT})
     set(VCPKG_ROOT $ENV{VCPKG_ROOT})
-    set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "Toolchain file for vcpkg" FORCE)
-	
-	# Set Boost paths
-    set(BOOST_ROOT "${VCPKG_ROOT}/installed/x64-windows" CACHE PATH "Boost installation root")
-    set(Boost_INCLUDE_DIR "${VCPKG_ROOT}/installed/x64-windows/include" CACHE PATH "Boost include directory")
+    set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "Vcpkg toolchain file" FORCE)
+    set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING "Vcpkg target triplet")
+endif()
+
+# Enforce static MSVC runtime (/MT or /MTd)
+if(MSVC)
+    foreach(flag_var CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_DEBUG
+                     CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_DEBUG)
+        string(REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+    endforeach()
 endif()
 
 # Set Windows SDK version if available
@@ -25,11 +34,21 @@ if (DEFINED ENV{SDKVersion})
     set(CMAKE_SYSTEM_VERSION $ENV{SDKVersion})
 endif()
 
+# Enable Unicode globally
+add_definitions(-DUNICODE -D_UNICODE)
+
+# Enable warnings
+if (MSVC)
+    add_compile_options(/W4)
+else()
+    add_compile_options(-Wall -Wextra -pedantic)
+endif()
+
 # Enable testing framework
 enable_testing()
 
-# Enable Unicode globally
-add_definitions(-DUNICODE -D_UNICODE)
+# Find dependencies
+find_package(nlohmann_json CONFIG REQUIRED)
 
 # Include subdirectories for main and test executables
 add_subdirectory(src)  # Add main executable's CMake

--- a/LogMonitor/LogMonitorTests/CMakeLists.txt
+++ b/LogMonitor/LogMonitorTests/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(LogMonitorTests)
 
-find_package(Boost REQUIRED COMPONENTS json)
+find_package(nlohmann_json CONFIG REQUIRED)
 
 # Automatically gather all test source files
 file(GLOB_RECURSE TEST_SOURCES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.cpp")
@@ -22,7 +22,7 @@ target_compile_definitions(LogMonitorTests PRIVATE LOGMONITORTESTS_EXPORTS)
 target_include_directories(LogMonitorTests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}  # Includes Utility.h and pch.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
-    ${Boost_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/LogMonitor
 )
 
 # Set Windows-specific linker flags
@@ -33,8 +33,8 @@ set_target_properties(LogMonitorTests PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
 )
 
-# Link LogMonitor and Boost.JSON
-target_link_libraries(LogMonitorTests PRIVATE LogMonitor Boost::json)
+# Link LogMonitor and Nlohmann JSON
+target_link_libraries(LogMonitorTests PRIVATE LogMonitorLib nlohmann_json::nlohmann_json)
 
 # Enable testing
 enable_testing()

--- a/LogMonitor/LogMonitorTests/UtilityTests.cpp
+++ b/LogMonitor/LogMonitorTests/UtilityTests.cpp
@@ -60,6 +60,7 @@ namespace UtilityTests
             std::wstring expect = L"say, \\\"hello\\\"";
             Utility::SanitizeJson(str);
             Assert::IsTrue(str == expect, L"should escape \"");
+
             str = L"\"hello\"";
             expect = L"\\\"hello\\\"";
             Utility::SanitizeJson(str);
@@ -69,6 +70,7 @@ namespace UtilityTests
             expect = L"hello\\r\\nworld";
             Utility::SanitizeJson(str);
             Assert::IsTrue(str == expect, L"should escape \r and \n");
+
             str = L"\r\nHello\r\n";
             expect = L"\\r\\nHello\\r\\n";
             Utility::SanitizeJson(str);
@@ -78,6 +80,7 @@ namespace UtilityTests
             expect = L"\\\\Driver\\\\XX\\\\";
             Utility::SanitizeJson(str);
             Assert::IsTrue(str == expect, L"should escape \\");
+
             str = L"C:\\Drive\\XX";
             expect = L"C:\\\\Drive\\\\XX";
             Utility::SanitizeJson(str);

--- a/LogMonitor/LogMonitorTests/pch.h
+++ b/LogMonitor/LogMonitorTests/pch.h
@@ -52,6 +52,7 @@
 #include <direct.h >
 #include <io.h> 
 #include <fcntl.h> 
+#include <nlohmann/json.hpp>
 #include "../src/LogMonitor/Utility.h"
 #include "../src/LogMonitor/Parser/ConfigFileParser.h"
 #include "../src/LogMonitor/Parser/LoggerSettings.h"

--- a/LogMonitor/docs/README.md
+++ b/LogMonitor/docs/README.md
@@ -192,7 +192,7 @@ Example 1 (Application channel, verboseness: Error):
         "channels": [
           {
             "name": "system",
-            "level": " Information"
+            "level": "Information"
           }
         ]
       }

--- a/LogMonitor/src/CMakeLists.txt
+++ b/LogMonitor/src/CMakeLists.txt
@@ -2,22 +2,45 @@ cmake_minimum_required(VERSION 3.15)
 
 project(LogMonitor)
 
-find_package(Boost REQUIRED COMPONENTS json)
+find_package(nlohmann_json CONFIG REQUIRED)
 
+# Gather source files
 file(GLOB_RECURSE SourceFiles RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.cpp")
+file(GLOB_RECURSE HeaderFiles RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.h")
 
-# Define LogMonitor as a library
-add_library(LogMonitor ${SourceFiles})
+# Define LogMonitorLib as a static library
+add_library(LogMonitorLib STATIC ${SourceFiles})
+
+# Set the output name of the static library to "LogMonitor.lib"
+set_target_properties(LogMonitorLib PROPERTIES
+    OUTPUT_NAME "LogMonitor"
+)
+
+# Define LogMonitor as an executable
+add_executable(LogMonitor ${SourceFiles})
 
 # Add precompiled headers (PCH)
 target_precompile_headers(LogMonitor PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/LogMonitor/pch.h)
 
-# Include directories for LogMonitor
-target_include_directories(LogMonitor PRIVATE
+# Include directories for both targets
+target_include_directories(LogMonitorLib PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/LogMonitor
-	${CMAKE_CURRENT_SOURCE_DIR}/LogMonitor/FileMonitor
-    ${Boost_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/LogMonitor/FileMonitor
 )
 
-# Link Boost JSON to LogMonitor
-target_link_libraries(LogMonitor PRIVATE Boost::json)
+target_include_directories(LogMonitor PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/LogMonitor
+    ${CMAKE_CURRENT_SOURCE_DIR}/LogMonitor/FileMonitor
+)
+
+# Link dependencies
+target_link_libraries(LogMonitorLib PRIVATE nlohmann_json::nlohmann_json)
+target_link_libraries(LogMonitor PRIVATE LogMonitorLib nlohmann_json::nlohmann_json)
+
+# Set output path
+set_target_properties(LogMonitor PROPERTIES
+	OUTPUT_NAME "LogMonitor"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+)

--- a/LogMonitor/src/LogMonitor/JsonProcessor.cpp
+++ b/LogMonitor/src/LogMonitor/JsonProcessor.cpp
@@ -135,11 +135,11 @@ bool handleEventLog(
 
         // Process channels if they exist
         if (source.contains("channels") && source["channels"].is_array()) {
-            auto channels = new std::vector<EventLogChannel>();
+            auto channels = std::make_unique<std::vector<EventLogChannel>>();
 
             for (const auto& channel : source["channels"]) {
-                std::string name = getJsonStringCaseInsensitive(channel, "name");
-                std::string levelString = getJsonStringCaseInsensitive(channel, "level");
+                std::string name = getJsonStringCaseInsensitive(channel, "name", true);
+                std::string levelString = getJsonStringCaseInsensitive(channel, "level", true);
 
                 EventLogChannel eventChannel(Utility::string_to_wstring(name), EventChannelLogLevel::Error);
 
@@ -152,14 +152,13 @@ bool handleEventLog(
                             levelString.c_str()
                         ).c_str()
                     );
-                    delete channels; // Prevent leak
                     return false;
                 }
 
                 channels->push_back(eventChannel);
             }
 
-            Attributes[JSON_TAG_CHANNELS] = reinterpret_cast<void*>(channels);
+            Attributes[JSON_TAG_CHANNELS] = reinterpret_cast<void*>(channels.release());
         }
         else {
             Attributes[JSON_TAG_CHANNELS] = nullptr;
@@ -200,7 +199,7 @@ bool handleFileLog(
     _In_ AttributesMap& Attributes,
     _Inout_ std::vector<std::shared_ptr<LogSource>>& Sources
 ) {
-    std::string directory = getJsonStringCaseInsensitive(source, "directory");
+    std::string directory = getJsonStringCaseInsensitive(source, "directory", true);
     std::string filter = getJsonStringCaseInsensitive(source, "filter");
     bool includeSubdirs = false;
     if (source.contains("includeSubdirectories") && source["includeSubdirectories"].is_boolean()) {
@@ -242,7 +241,7 @@ bool handleFileLog(
 /// otherwise, returns false if parsing fails.
 /// </returns>
 bool handleETWLog(
-    _In_ const nlohmann::json& source,
+    _In_ const json& source,
     _In_ AttributesMap& Attributes,
     _Inout_ std::vector<std::shared_ptr<LogSource>>& Sources
 ) {
@@ -268,9 +267,9 @@ bool handleETWLog(
 
     if (source.contains("providers") && source["providers"].is_array()) {
         for (const auto& provider : source["providers"]) {
-            std::string providerName = getJsonStringCaseInsensitive(provider, "providerName");
-            std::string providerGuid = getJsonStringCaseInsensitive(provider, "providerGuid");
-            std::string level = getJsonStringCaseInsensitive(provider, "level");
+            std::string providerName = getJsonStringCaseInsensitive(provider, "providerName", true);
+            std::string providerGuid = getJsonStringCaseInsensitive(provider, "providerGuid", true);
+            std::string level = getJsonStringCaseInsensitive(provider, "level", true);
 
             ETWProvider etwProvider;
             etwProvider.ProviderName = Utility::string_to_wstring(providerName);
@@ -317,7 +316,7 @@ bool handleETWLog(
 /// otherwise, returns false if parsing fails.
 /// </returns>
 bool handleProcessLog(
-    _In_ const nlohmann::json& source,
+    _In_ const json& source,
     _In_ AttributesMap& Attributes,
     _Inout_ std::vector<std::shared_ptr<LogSource>>& Sources
 ) {
@@ -475,7 +474,7 @@ void cleanupAttributes(_In_ AttributesMap& Attributes) {
 /// <param name="obj">The JSON object to search for the key.</param>
 /// <param name="key">The key to search for in the JSON object, case-insensitive.</param>
 /// <returns>string value associated with the key if found </returns>
-std::string getJsonStringCaseInsensitive(_In_ const nlohmann::json& obj, _In_ const std::string& key) {
+std::string getJsonStringCaseInsensitive(_In_ const nlohmann::json& obj, _In_ const std::string& key, _In_ bool required) {
     auto lowerKey = key;
     std::transform(lowerKey.begin(), lowerKey.end(), lowerKey.begin(), ::tolower);
 
@@ -487,11 +486,13 @@ std::string getJsonStringCaseInsensitive(_In_ const nlohmann::json& obj, _In_ co
         }
     }
 
-    logWriter.TraceError(
-        Utility::FormatString(
-            L"Key %S not found in JSON object", key.c_str()
-        ).c_str()
-    );
+    if (required) {
+        logWriter.TraceError(
+            Utility::FormatString(
+                L"Key %S not found in JSON object", key.c_str()
+            ).c_str()
+        );
+    }
 
     return "";
 }

--- a/LogMonitor/src/LogMonitor/JsonProcessor.h
+++ b/LogMonitor/src/LogMonitor/JsonProcessor.h
@@ -6,25 +6,25 @@
 #pragma once
 
 bool handleEventLog(
-    _In_ const boost::json::value& source,
+    _In_ const nlohmann::json& source,
     _In_ AttributesMap& Attributes,
     _Inout_ std::vector<std::shared_ptr<LogSource>>& Sources
 );
 
 bool handleFileLog(
-    _In_ const boost::json::value& source,
+    _In_ const nlohmann::json& source,
     _In_ AttributesMap& Attributes,
     _Inout_ std::vector<std::shared_ptr<LogSource>>& Sources
 );
 
 bool handleETWLog(
-    _In_ const boost::json::value& source,
+    _In_ const nlohmann::json& source,
     _In_ AttributesMap& Attributes,
     _Inout_ std::vector<std::shared_ptr<LogSource>>& Sources
 );
 
 bool handleProcessLog(
-    _In_ const boost::json::value& source,
+    _In_ const nlohmann::json& source,
     _In_ AttributesMap& Attributes,
     _Inout_ std::vector<std::shared_ptr<LogSource>>& Sources
 );
@@ -39,12 +39,12 @@ std::string readJsonFromFile(
 );
 
 bool processLogConfig(
-    const boost::json::value& logConfig,
+    const nlohmann::json& logConfig,
     _Out_ LoggerSettings& Config
 );
 
 bool processSources(
-    const boost::json::array& sources, 
+    _In_ const nlohmann::json& sources,
     _Out_ LoggerSettings& Config
 );
 
@@ -53,6 +53,6 @@ void cleanupAttributes(
 );
 
 std::string getJsonStringCaseInsensitive(
-    _In_ const boost::json::object& obj, 
+    _In_ const nlohmann::json& obj,
     _In_ const std::string& key
 );

--- a/LogMonitor/src/LogMonitor/JsonProcessor.h
+++ b/LogMonitor/src/LogMonitor/JsonProcessor.h
@@ -54,5 +54,6 @@ void cleanupAttributes(
 
 std::string getJsonStringCaseInsensitive(
     _In_ const nlohmann::json& obj,
-    _In_ const std::string& key
+    _In_ const std::string& key,
+    _In_ bool required = false
 );

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -290,8 +290,10 @@ void Utility::SanitizeJson(_Inout_ std::wstring& str)
     }
     catch (const json::exception& e)
     {
-        std::wcerr << L"SanitizeJson failed: " << Utility::string_to_wstring(e.what()) << std::endl;
-        str = L"[invalid JSON string]";
+        // Leave str unchanged — emitting unescaped content is better than losing the log line.
+        logWriter.TraceError(
+            Utility::FormatString(L"SanitizeJson failed: %S", e.what()).c_str()
+        );
     }
 }
 

--- a/LogMonitor/src/LogMonitor/pch.h
+++ b/LogMonitor/src/LogMonitor/pch.h
@@ -47,7 +47,7 @@
 #include "shlwapi.h"
 #include <io.h> 
 #include <fcntl.h>
-#include <boost/json.hpp>
+#include <nlohmann/json.hpp>
 #include "Utility.h"
 #include "Parser/ConfigFileParser.h"
 #include "Parser/LoggerSettings.h"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,9 +10,10 @@ pool:
 
 variables:
   solution: '**/*.sln'
-  buildPlatform: 'x64'  # Set to x64 or ARM64 depending on the build you want
+  buildPlatform: 'x64'
   buildConfiguration: 'Release'
   VCPKG_ROOT: '$(Build.SourcesDirectory)\vcpkg'
+  VCPKG_TRIPLET: 'x64-windows-static'
   VCPKG_CMAKE_OPTIONS: '-DCMAKE_TOOLCHAIN_FILE=$(VCPKG_ROOT)\scripts\buildsystems\vcpkg.cmake'
   SDKVersion: ''
 
@@ -28,11 +29,10 @@ jobs:
             git clone https://github.com/microsoft/vcpkg.git $(VCPKG_ROOT)
             cd $(VCPKG_ROOT)
             .\bootstrap-vcpkg.bat
-            .\vcpkg.exe integrate install  # Integrate vcpkg with MSBuild
+            .\vcpkg.exe integrate install
 
-      # Install Boost JSON for the selected platform (x64 or ARM64)
       - task: PowerShell@2
-        displayName: 'Install Boost JSON'
+        displayName: 'Install nlohmann_json'
         inputs:
           targetType: 'inline'
           script: |
@@ -40,38 +40,9 @@ jobs:
                 Write-Error "vcpkg.exe not found. Exiting..."
                 exit 1
             }
-            Write-Host "Installing Boost JSON for platform: $(buildPlatform)..."
-            if ('$(buildPlatform)' -eq 'x64') {
-              & "$(VCPKG_ROOT)\vcpkg.exe" install boost-json:x64-windows
-            } elseif ('$(buildPlatform)' -eq 'ARM64') {
-              & "$(VCPKG_ROOT)\vcpkg.exe" install boost-json:arm64-windows
-            } else {
-              Write-Error "Unsupported build platform: $(buildPlatform)"
-              exit 1
-            }
+            Write-Host "Installing nlohmann_json for platform: $(VCPKG_TRIPLET)..."
+            & "$(VCPKG_ROOT)\vcpkg.exe" install nlohmann-json:$(VCPKG_TRIPLET)
 
-      # Verify vcpkg integration
-      - task: PowerShell@2
-        displayName: 'Verify vcpkg Integration'
-        inputs:
-          targetType: 'inline'
-          script: |
-            echo "Verifying vcpkg integration for platform: $(buildPlatform)..."
-            & "$(VCPKG_ROOT)\vcpkg.exe" integrate install
-            if ('$(buildPlatform)' -eq 'x64') {
-                if (!(Test-Path "$(VCPKG_ROOT)\installed\x64-windows\include\boost\json.hpp")) {
-                    Write-Error "Boost JSON header not found for x64. Exiting..."
-                    exit 1
-                }
-            } elseif ('$(buildPlatform)' -eq 'ARM64') {
-                if (!(Test-Path "$(VCPKG_ROOT)\installed\arm64-windows\include\boost\json.hpp")) {
-                    Write-Error "Boost JSON header not found for ARM64. Exiting..."
-                    exit 1
-                }
-            }
-            Write-Output "vcpkg integration verified."
-
-      # Get installed Windows SDK version
       - task: PowerShell@2
         displayName: 'Check Installed Windows SDK Version'
         inputs:
@@ -104,13 +75,12 @@ jobs:
                 exit 1
             }
 
-      # Configure CMake based on selected platform
       - task: CMake@1
         displayName: 'Configure CMake'
         inputs:
           workingDirectory: '$(Build.SourcesDirectory)\LogMonitor'
           cmakeArgs: |
-            -A $(buildPlatform) -S $(Build.SourcesDirectory)\LogMonitor -B $(Build.BinariesDirectory)\LogMonitor\$(buildPlatform)
+            -A $(buildPlatform) -S $(Build.SourcesDirectory)\LogMonitor -B $(Build.BinariesDirectory)\LogMonitor\$(buildPlatform) $(VCPKG_CMAKE_OPTIONS) -DVCPKG_TARGET_TRIPLET=$(VCPKG_TRIPLET)
 
       - task: CMake@1
         displayName: 'Build with CMake'
@@ -118,20 +88,17 @@ jobs:
           workingDirectory: '$(Build.BinariesDirectory)\LogMonitor\$(buildPlatform)'
           cmakeArgs: '--build . --config $(buildConfiguration) --parallel'
 
-      # Component Governance
       - task: ComponentGovernanceComponentDetection@0
         inputs:
           scanType: 'Register'
           verbosity: 'Verbose'
           alertWarningLevel: 'Low'
 
-      # Install Visual Studio Test Platform
       - task: VisualStudioTestPlatformInstaller@1
         inputs:
           packageFeedSelector: 'nugetOrg'
           versionSelector: 'latestPreRelease'
 
-      # Run Tests
       - task: VSTest@2
         inputs:
           testSelector: 'testAssemblies'
@@ -142,7 +109,6 @@ jobs:
           rerunFailedTests: true
           rerunMaxAttempts: 3
 
-      # Publish build artifacts
       - task: PublishPipelineArtifact@1
         inputs:
           targetPath: '$(Build.BinariesDirectory)\LogMonitor\$(buildPlatform)\$(buildConfiguration)\'

--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,64 @@
-msbuild LogMonitor\LogMonitor.sln /p:platform=x64 /p:configuration=Release
+@echo off
+setlocal
+
+REM Set the path to the LogMonitor folder
+set PROJECT_DIR=%~dp0LogMonitor
+
+REM Set up environment variables
+set VCPKG_DIR=%~dp0vcpkg
+set BUILD_DIR=%~dp0build
+set TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake
+set BUILD_TYPE=Release
+set BUILD_ARCH=x64
+set VCPKG_TRIPLET=%BUILD_ARCH%-windows-static
+
+REM Step 1: Clone and bootstrap vcpkg if not already done
+if not exist "%VCPKG_DIR%\vcpkg.exe" (
+    echo === Cloning vcpkg ===
+    git clone https://github.com/microsoft/vcpkg.git "%VCPKG_DIR%"
+    echo === Bootstrapping vcpkg ===
+    pushd "%VCPKG_DIR%"
+    .\bootstrap-vcpkg.bat
+    popd
+)
+
+REM Step 2: Install nlohmann-json dependencies
+echo === Installing nlohmann dependencies ===
+"%VCPKG_DIR%\vcpkg.exe" install nlohmann-json:%VCPKG_TRIPLET%
+
+if errorlevel 1 (
+    echo Failed to install nlohmann-json dependencies.
+    exit /b 1
+)
+
+REM Create the build directory if it doesn't exist
+if not exist "%PROJECT_DIR%\build" (
+    mkdir "%PROJECT_DIR%\build"
+)
+
+REM Navigate into the build directory
+cd /d "%PROJECT_DIR%\build"
+
+REM Run CMake configuration with toolchain and triplet
+cmake .. ^
+ -DCMAKE_TOOLCHAIN_FILE=%TOOLCHAIN_FILE% ^
+ -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ^
+ -DVCPKG_TARGET_TRIPLET=%VCPKG_TRIPLET% ^
+ -A %BUILD_ARCH%
+ 
+if errorlevel 1 (
+    echo CMake configuration failed.
+    exit /b 1
+)
+
+REM Build the project
+cmake --build . --config %BUILD_TYPE% --parallel
+
+if errorlevel 1 (
+    echo Build failed.
+    exit /b 1
+)
+
+echo === Build completed successfully ===
+
+endlocal

--- a/build.cmd
+++ b/build.cmd
@@ -22,7 +22,23 @@ if not exist "%VCPKG_DIR%\vcpkg.exe" (
     popd
 )
 
-REM Step 2: Install nlohmann-json dependencies
+REM Step 2: Locate cmake — prefer PATH, then VS, then vcpkg's downloaded copy
+where cmake >nul 2>&1
+if errorlevel 1 (
+    if exist "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" (
+        set "PATH=%PATH%;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+        goto cmake_found
+    )
+    for /f "delims=" %%i in ('dir /s /b "%VCPKG_DIR%\downloads\tools\cmake-*\bin\cmake.exe" 2^>nul') do (
+        set "PATH=%PATH%;%%~dpi"
+        goto cmake_found
+    )
+    echo cmake not found. Install cmake or Visual Studio CMake tools.
+    exit /b 1
+)
+:cmake_found
+
+REM Step 3: Install nlohmann-json dependencies
 echo === Installing nlohmann dependencies ===
 "%VCPKG_DIR%\vcpkg.exe" install nlohmann-json:%VCPKG_TRIPLET%
 
@@ -31,7 +47,7 @@ if errorlevel 1 (
     exit /b 1
 )
 
-REM Create the build directory if it doesn't exist
+REM Step 4: Create the build directory if it doesn't exist
 if not exist "%PROJECT_DIR%\build" (
     mkdir "%PROJECT_DIR%\build"
 )


### PR DESCRIPTION
This pull request makes the following changes:

- **Switches JSON handling from Boost to nlohmann::json**
Replaces the previous configuration file parsing logic that used Boost with nlohmann::json for improved readability and maintainability.

- **Log output sanitization using nlohmann::json**
Sanitizes log output using nlohmann::json to ensure consistency and safety in serialized data.

- **Migrates build system to CMake**
Refactors the build.cmd script to replace the MSBuild-based approach with a CMake-based build system for greater portability and modern tooling support.

- **Enables static linking**
Configures the build for static linking to avoid runtime dependency issues on target machines.