### PR TITLE
Fix JSON parser to correctly handle numeric values

### DIFF
--- a/LogMonitor/src/LogMonitor/JsonFileParser.cpp
+++ b/LogMonitor/src/LogMonitor/JsonFileParser.cpp
@@ -248,9 +248,10 @@ JsonFileParser::ParseNumber()
         else
         {
             //
-            // End of string.
+            // End of number parsing.
+            // The terminating character (comma, bracket, brace, etc.) must remain unconsumed for subsequent
+            // parsing steps
             //
-            offset++;
             AdvanceBufferPointer(offset);
 
             m_doubleValue = negativeValue ? -parsedValue : parsedValue;


### PR DESCRIPTION
The fix involved removing an unnecessary increment (offset++) before advancing the buffer pointer in the ParseNumber() function of your JSON parser. Previously, after parsing a numeric value, the code advanced the offset one extra character, which caused the parser to skip over important JSON structural characters like commas (,) or closing braces (}) that separate or terminate object members. This led to errors when parsing numbers that were not the last member in an object.

By eliminating the extra increment, the parser now correctly leaves the structural character in place for the next parsing step, ensuring proper handling of multi-digit numbers and correct traversal of JSON objects regardless of the order of their members. This change makes the parser robust and compliant with standard JSON syntax, preventing premature end-of-object errors.