### PR TITLE
Document missing `EventSource` field

### DIFF
--- a/LogMonitor/docs/README.md
+++ b/LogMonitor/docs/README.md
@@ -387,7 +387,7 @@ Each log source tracked by log monitor <em>(ETW, Log File, Events, and Process M
 <strong>Event Logs:</strong>
   - `Source`: The log source (Event Log)
   - `TimeStamp`: Time at which the event was generated
-  - `EventSource`: The event source
+  - `EventSource`: The source of an event
   - `EventID`: Unique identifier assigned to an individual event
   - `Severity`: A label that indicates the importance or criticality of an event
   - `Message`: The event message


### PR DESCRIPTION
Add `EventSource` field to the list.

See: https://github.com/microsoft/windows-container-tools/blob/main/LogMonitor/src/LogMonitor/EventMonitor.cpp#L835