### PR TITLE
Enable Control Flow Guard (CFG) for Release builds

### DIFF
--- a/LogMonitor/src/CMakeLists.txt
+++ b/LogMonitor/src/CMakeLists.txt
@@ -37,6 +37,11 @@ target_include_directories(LogMonitor PRIVATE
 target_link_libraries(LogMonitorLib PRIVATE nlohmann_json::nlohmann_json)
 target_link_libraries(LogMonitor PRIVATE LogMonitorLib nlohmann_json::nlohmann_json)
 
+if(MSVC)
+    target_compile_options(LogMonitor PRIVATE /guard:cf)
+    target_link_options(LogMonitor PRIVATE /guard:cf)
+endif()
+
 # Set output path — use $<CONFIG> so Release/Debug binaries go into separate subdirectories,
 # matching the pipeline's $(buildConfiguration) layout.
 set_target_properties(LogMonitor PROPERTIES

--- a/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
+++ b/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
@@ -125,12 +125,14 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -144,6 +146,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -151,6 +154,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
Add <ControlFlowGuard>Guard</ControlFlowGuard> to both ClCompile and Link sections in the vcxproj for Release|Win32 and Release|x64 configurations. Also add /guard:cf compiler and linker flags in CMakeLists.txt for MSVC builds.

Fixes #230 